### PR TITLE
Allow for more than one user in Authorization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,8 @@ export default {
     if (req.method === 'OPTIONS') return daResp({ status: 204 });
 
     const daCtx = await getDaCtx(pathname, req, env);
-    const authed = await isAuthorized(env, daCtx.org, daCtx.user);
-    if (!authed) {
+
+    if (!daCtx.authorized) {
       return daResp({ body: '', status: 401 });
     }
 

--- a/src/utils/daCtx.js
+++ b/src/utils/daCtx.js
@@ -9,7 +9,7 @@
  */
 
 import getObject from '../storage/object/get';
-import { getUser, isAuthorized } from './auth';
+import { getUsers, isAuthorized } from './auth';
 
 /**
  * Gets Dark Alley Context
@@ -17,9 +17,9 @@ import { getUser, isAuthorized } from './auth';
  * @returns {DaCtx} The Dark Alley Context.
  */
 export async function getDaCtx(pathname, req, env) {
-  const user = await getUser(req, env);
+  const users = await getUsers(req, env);
 
-  console.log(user);
+  console.log(users);
 
   // Santitize the string
   const lower = pathname.slice(1).toLowerCase();
@@ -29,11 +29,16 @@ export async function getDaCtx(pathname, req, env) {
   const [api, org, ...parts] = sanitized.split('/');
 
   // Set base details
-  const daCtx = { api, org, user };
+  const daCtx = { api, org, users };
 
   // Get org properties
-  if (org) {
-    daCtx.authorized = await isAuthorized(env, org, user);
+  daCtx.authorized = true;
+  // check for all users in the session if they are authorized
+  for (let user in users) {
+    if (!await isAuthorized(env, org, user)) {
+      daCtx.authorized = false;
+      break;
+    }
   }
 
   // Sanitize the remaining path parts


### PR DESCRIPTION
Collab sessions can result in more than one user being responsible for a PUT - this PR makes it so that we da-admin allows more than one entry in the Authorization header and checks for all if the respective users is authorized. As a special case, it allows for an empty entry in the list of tokens which is interpreted as an anon user being present as well.