### PR TITLE
GH-24 - Allow /api path prefix

### DIFF
--- a/src/utils/daCtx.js
+++ b/src/utils/daCtx.js
@@ -18,7 +18,9 @@ import { getUsers, isAuthorized } from './auth.js';
  * @returns {DaCtx} The Dark Alley Context.
  */
 export default async function getDaCtx(req, env) {
-  const { pathname } = new URL(req.url);
+  let { pathname } = new URL(req.url);
+  // Remove proxied api route
+  if (pathname.startsWith('/api')) pathname = pathname.replace('/api', '');
 
   const users = await getUsers(req, env);
 

--- a/test/utils/daCtx.test.js
+++ b/test/utils/daCtx.test.js
@@ -12,6 +12,18 @@ const getDaCtx = await esmock(
 );
 
 describe('Dark Alley context', () => {
+  describe('API context', async () => {
+    let daCtx;
+
+    before(async () => {
+      daCtx = await getDaCtx(reqs.api, env);
+    });
+
+    it('should remove api from path name', () => {
+      assert.strictEqual(daCtx.api, 'source');
+    });
+  });
+
   describe('Org context', async () => {
     let daCtx;
 

--- a/test/utils/mocks/req.js
+++ b/test/utils/mocks/req.js
@@ -45,6 +45,7 @@ const optsWithForceFail = {
 };
 
 const reqs = {
+  api: new Request('https://da.live/api/source/cq/', optsWithEmptyHead),
   org: new Request('https://da.live/source/cq/', optsWithEmptyHead),
   site: new Request('https://da.live/source/cq/Geometrixx', optsWithAuth),
   folder: new Request('https://da.live/source/cq/Geometrixx/NFT/', optsWithExpAuth),


### PR DESCRIPTION
* Support prefixing all routes with `/api`

Resolves: GH-24

## How Has This Been Tested?

1. Passing unit tests
2. Validated `da-admin` only uses pathname provided by daCtx.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
