### PR TITLE
Inform da-collab about deleted document

### DIFF
--- a/src/handlers/delete.js
+++ b/src/handlers/delete.js
@@ -11,10 +11,10 @@
  */
 import { deleteSource } from '../routes/source.js';
 
-export default async function deleteHandler({ env, daCtx }) {
+export default async function deleteHandler({ req, env, daCtx }) {
   const { path } = daCtx;
 
-  if (path.startsWith('/source')) return deleteSource({ env, daCtx });
+  if (path.startsWith('/source')) return deleteSource({ req, env, daCtx });
 
   return undefined;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ export default {
         respObj = await postHandler({ req, env, daCtx });
         break;
       case 'DELETE':
-        respObj = await deleteHandler({ env, daCtx });
+        respObj = await deleteHandler({ req, env, daCtx });
         break;
       default:
         respObj = unkownHandler();

--- a/src/storage/object/delete.js
+++ b/src/storage/object/delete.js
@@ -71,5 +71,5 @@ export default async function deleteObjects(env, daCtx) {
     }
   } while (ContinuationToken);
 
-  return { body: '', status: 204 };
+  return { body: null, status: 204 };
 }

--- a/test/routes/source.test.js
+++ b/test/routes/source.test.js
@@ -186,7 +186,15 @@ describe('Source Route', () => {
   });
 
   it('Test deleteSource', async () => {
-    const env = {};
+    const req = {
+      headers: new Map(),
+      url: 'http://somehost.com/somedoc.html'
+    };
+
+    const daCalled = []
+    const dacollab = { fetch: (u) => daCalled.push(u) };
+
+    const env = { dacollab };
     const daCtx = {};
 
     const called = [];
@@ -204,8 +212,10 @@ describe('Source Route', () => {
         }
       }
     );
-    const resp = await deleteSource({env, daCtx});
+    const resp = await deleteSource({req, env, daCtx});
     assert.equal(204, resp.status);
     assert.deepStrictEqual(called, ['deleteObject']);
+    assert.deepStrictEqual(daCalled,
+      ['https://localhost/api/v1/deleteadmin?doc=http://somehost.com/somedoc.html']);
   });
 });


### PR DESCRIPTION
## Description

When a document is deleted from da-admin, it invokes da-collab with the following API

```
  /api/v1/deleteadmin?doc=${documentURL}
```

This enables da-collab to clean up.

If a service binding is configured, da-admin will use the service binding to reach da-collab.

Needs https://github.com/adobe/da-collab/pull/36 to be merged in order to work.

## Related Issue

#30 

## How Has This Been Tested?

* Tested with unit tests
* Also tested locally with da-live and da-collab

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
