### PR TITLE
Support version naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+.vscode
+

--- a/src/handlers/patch.js
+++ b/src/handlers/patch.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { patchVersion } from '../routes/version.js';
+
+export default async function patchHandler({ req, env, daCtx }) {
+  const { path } = daCtx;
+
+  if (path.startsWith('/version')) return patchVersion({ req, env, daCtx });
+
+  return undefined;
+}

--- a/src/handlers/patch.js
+++ b/src/handlers/patch.js
@@ -14,7 +14,7 @@ import { patchVersion } from '../routes/version.js';
 export default async function patchHandler({ req, env, daCtx }) {
   const { path } = daCtx;
 
-  if (path.startsWith('/version')) return patchVersion({ req, env, daCtx });
+  if (path.startsWith('/versionsource')) return patchVersion({ req, env, daCtx });
 
   return undefined;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import daResp from './utils/daResp.js';
 
 import headHandler from './handlers/head.js';
 import getHandler from './handlers/get.js';
+import patchHandler from './handlers/patch.js';
 import postHandler from './handlers/post.js';
 import deleteHandler from './handlers/delete.js';
 import unkownHandler from './handlers/unkown.js';
@@ -43,6 +44,9 @@ export default {
         break;
       case 'DELETE':
         respObj = await deleteHandler({ env, daCtx });
+        break;
+      case 'PATCH':
+        respObj = await patchHandler({ req, env, daCtx });
         break;
       default:
         respObj = unkownHandler();

--- a/src/routes/version.js
+++ b/src/routes/version.js
@@ -12,6 +12,7 @@
 
 import { getObjectVersion } from '../storage/version/get.js';
 import { listObjectVersions } from '../storage/version/list.js';
+import { patchObjectVersion } from '../storage/version/patch.js';
 import { postObjectVersion } from '../storage/version/put.js';
 
 export async function getVersionList({ env, daCtx }) {
@@ -20,6 +21,10 @@ export async function getVersionList({ env, daCtx }) {
 
 export async function getVersionSource({ env, daCtx, head }) {
   return getObjectVersion(env, daCtx, head);
+}
+
+export async function patchVersion({ req, env, daCtx }) {
+  return patchObjectVersion(req, env, daCtx);
 }
 
 export async function postVersionSource({ env, daCtx }) {

--- a/src/storage/version/list.js
+++ b/src/storage/version/list.js
@@ -25,7 +25,7 @@ export async function listObjectVersions(env, { org, key }) {
     }, true);
     const timestamp = parseInt(entryResp.metadata.timestamp || '0', 10);
     const users = JSON.parse(entryResp.metadata.users || '[{"email":"anonymous"}]');
-    const { displayName, path } = entryResp.metadata;
+    const { displayname, path } = entryResp.metadata;
 
     if (entryResp.contentLength > 0) {
       return {
@@ -33,7 +33,7 @@ export async function listObjectVersions(env, { org, key }) {
         users,
         timestamp,
         path,
-        displayName,
+        displayname,
       };
     }
     return { users, timestamp, path };

--- a/src/storage/version/list.js
+++ b/src/storage/version/list.js
@@ -25,7 +25,7 @@ export async function listObjectVersions(env, { org, key }) {
     }, true);
     const timestamp = parseInt(entryResp.metadata.timestamp || '0', 10);
     const users = JSON.parse(entryResp.metadata.users || '[{"email":"anonymous"}]');
-    const { path } = entryResp.metadata;
+    const { displayName, path } = entryResp.metadata;
 
     if (entryResp.contentLength > 0) {
       return {
@@ -33,6 +33,7 @@ export async function listObjectVersions(env, { org, key }) {
         users,
         timestamp,
         path,
+        displayName,
       };
     }
     return { users, timestamp, path };

--- a/src/storage/version/patch.js
+++ b/src/storage/version/patch.js
@@ -31,7 +31,7 @@ export async function patchObjectVersion(req, env, daCtx) {
   const update = buildInput(daCtx);
   const current = await getObject(env, { org, key: `.da-versions/${key}` });
   if (current.status === 404) {
-    return 404;
+    return { status: current.status };
   }
   const resp = await putVersion(config, {
     Bucket: update.Bucket,

--- a/src/storage/version/patch.js
+++ b/src/storage/version/patch.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import getObject from '../object/get.js';
+import listObjects from '../object/list.js';
+import putObject from '../object/put.js';
+
+export async function patchObjectVersion(req, env, daCtx) {
+  const { org, key } = daCtx;
+  const rb = await req.json();
+
+  const current = await getObject(env, { org, key }, true);
+  if (current.status === 404 || !current.metadata.id) {
+    return 404;
+  }
+  const resp = await listObjects(env, { org, key: `.da-versions/${current.metadata.id}` });
+  const json = JSON.parse(resp.body);
+
+  for (const entry of json) {
+    const entryURL = `/versionsource/${org}/${current.metadata.id}/${entry.name}.${entry.ext}`;
+    if (entryURL === rb.url) {
+      // Found the version entry that matches
+      const versionObj = await getObject(env, {
+        org,
+        key: `.da-versions/${current.metadata.id}/${entry.name}.${entry.ext}`,
+      }, true);
+
+      // Update it with the display name (the only thing that can be patched)
+      // and store it
+      versionObj.metadata.displayName = rb.displayName;
+      return putObject(env, daCtx, versionObj);
+    }
+  }
+
+  return 404;
+}

--- a/src/storage/version/put.js
+++ b/src/storage/version/put.js
@@ -20,7 +20,7 @@ import {
 } from '../utils/version.js';
 import getObject from '../object/get.js';
 
-async function putVersion(config, {
+export async function putVersion(config, {
   Bucket, Body, ID, Version, Ext, Metadata,
 }, noneMatch = true) {
   const client = noneMatch ? ifNoneMatch(config) : createBucketIfMissing(new S3Client(config));

--- a/src/utils/daResp.js
+++ b/src/utils/daResp.js
@@ -17,7 +17,7 @@ export default function daResp({
 }) {
   const headers = new Headers();
   headers.append('Access-Control-Allow-Origin', '*');
-  headers.append('Access-Control-Allow-Methods', 'HEAD, GET, PUT, POST, DELETE');
+  headers.append('Access-Control-Allow-Methods', 'HEAD, GET, PUT, POST, DELETE, PATCH');
   headers.append('Access-Control-Allow-Headers', '*');
   headers.append('Content-Type', contentType);
   if (contentLength) {

--- a/test/storage/version/patch.test.js
+++ b/test/storage/version/patch.test.js
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import assert from 'assert';
+import esmock from 'esmock';
+
+describe('Version Patch', () => {
+  it('Patch Object unknown', async () => {
+    const req = { json: async () => JSON.parse('{"displayname": "Some version"}')};
+    const { patchObjectVersion } = await esmock(
+      '../../../src/storage/version/patch.js', {
+        '../../../src/storage/object/get.js': {
+          default: () => ({ status: 404 }),
+        }
+    });
+
+    const daCtx = {
+      org: 'org1',
+      key: 'mykey',
+    };
+
+    const resp = await patchObjectVersion(req, {}, daCtx);
+    assert.equal(404, resp.status);
+  })
+
+  it('Patch Object Version', async () => {
+    const req = { json: async () => JSON.parse('{"displayname": "Some version"}')};
+    const env = {
+      S3_DEF_URL: 's3def',
+      S3_ACCESS_KEY_ID: 'id',
+      S3_SECRET_ACCESS_KEY: 'secret'
+    };
+    const daCtx = {
+      org: 'org1',
+      key: 'mykey',
+      site: 'site1',
+      name: 'cafe1234',
+      ext: 'html'
+    };
+
+    const mockS3Client = class S3Client {
+      constructor(arg) {
+        this.arg = arg;
+      }
+    };
+
+    const mockedObject = {
+      body: 'obj body',
+      metadata: { timestamp: '999' }
+    };
+    const mockGetObject = async (e, c) => {
+      if (e === env
+        && c.org === 'org1'
+        && c.key === '.da-versions/mykey' ) {
+          return mockedObject;
+        } else {
+          assert.fail('Unexpected arguments passed to getObject()');
+        }
+    };
+
+    const pvCalled = [];
+    const mockPutVersion = (c, d, e) => {
+      pvCalled.push(c, d, e);
+      return { status: 200 };
+    }
+
+    const { patchObjectVersion } = await esmock(
+      '../../../src/storage/version/patch.js', {
+        '../../../src/storage/object/get.js': {
+          default: mockGetObject,
+        },
+        '../../../src/storage/version/put.js': {
+          putVersion: mockPutVersion
+        }
+    });
+
+    const resp = await patchObjectVersion(req, env, daCtx);
+    const pe = pvCalled[0];
+    assert.equal('auto', pe.region);
+    assert.equal('s3def', pe.endpoint);
+    assert.equal('id', pe.credentials.accessKeyId);
+    assert.equal('secret', pe.credentials.secretAccessKey);
+    assert(!pvCalled[2]);
+
+    // Check the data sent to putVersion
+    const de = pvCalled[1];
+    assert.equal('org1-content', de.Bucket);
+    assert.equal('obj body', de.Body);
+    assert.equal('site1', de.ID);
+    assert.equal('cafe1234', de.Version);
+    assert.equal('html', de.Ext);
+    assert.equal('[{"email":"anonymous"}]', de.Metadata.Users);
+    assert.equal('999', de.Metadata.Timestamp);
+    assert.equal('mykey', de.Metadata.Path);
+    assert.equal('Some version', de.Metadata.Displayname);
+    assert.equal(200, resp.status);
+  });
+
+  it('Patch Object Version 2', async () => {
+    const req = { json: async () => JSON.parse('{"displayname": "v999"}')};
+    const env = {};
+    const daCtx = {
+      org: 'org2',
+      key: 'some/key',
+      site: 'site1',
+      name: 'cafe1234',
+      ext: 'html'
+    };
+
+    const mockS3Client = class S3Client {
+      constructor(arg) {
+        this.arg = arg;
+      }
+    };
+
+    const mockedObject = {
+      body: 'obj body',
+      metadata: {
+        timestamp: '12345',
+        users: '[{"email":"jbloggs@acme"},{"email":"ablah@halba"}]',
+        path: 'goobar'
+      }
+    };
+    const mockGetObject = async (e, c) => {
+      if (e === env
+        && c.org === 'org2'
+        && c.key === '.da-versions/some/key' ) {
+          return mockedObject;
+        } else {
+          assert.fail('Unexpected arguments passed to getObject()');
+        }
+    };
+
+    const pvCalled = [];
+    const mockPutVersion = (c, d, e) => {
+      pvCalled.push(c, d, e);
+      return { status: 200 };
+    }
+
+    const { patchObjectVersion } = await esmock(
+      '../../../src/storage/version/patch.js', {
+        '../../../src/storage/object/get.js': {
+          default: mockGetObject,
+        },
+        '../../../src/storage/version/put.js': {
+          putVersion: mockPutVersion
+        }
+    });
+
+    const resp = await patchObjectVersion(req, env, daCtx);
+
+    // Check the data sent to putVersion
+    const de = pvCalled[1];
+    assert.equal('org2-content', de.Bucket);
+    assert.equal('obj body', de.Body);
+    assert.equal('site1', de.ID);
+    assert.equal('cafe1234', de.Version);
+    assert.equal('html', de.Ext);
+    assert.equal('[{"email":"jbloggs@acme"},{"email":"ablah@halba"}]', de.Metadata.Users);
+    assert.equal('12345', de.Metadata.Timestamp);
+    assert.equal('goobar', de.Metadata.Path);
+    assert.equal('v999', de.Metadata.Displayname);
+    assert.equal(200, resp.status);
+  });
+});


### PR DESCRIPTION
## Description

Make it possible to give a stored version a descriptive name. This can be done by sending a PATCH request to the version resource with as message body a JSON object with the `displayName`.

For example the PATCH request can be sent to the URL: `/versionsource/myorg/3246fe8b-3f32-481a-945a-786ee5a2133f/105ee238-c416-4371-896b-a16d1b0a4029.html` with data `{"displayName": "My Version"}`

## Related Issue

#6 

## How Has This Been Tested?

* Tested locally with curl
* Tested in combination with da-live 
* Tested via unit tests


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
