### PR TITLE
GH-35 - Self-service Authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@adobe/eslint-config-helix": "2.0.6",
         "@redocly/cli": "^1.4.1",
+        "aws-sdk-client-mock": "^4.0.0",
         "c8": "^8.0.1",
         "eslint": "8.56.0",
         "esmock": "^2.6.4",
@@ -1319,6 +1320,50 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "2.0.15",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.15.tgz",
@@ -2014,6 +2059,21 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/sinon": {
+      "version": "10.0.20",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.20.tgz",
+      "integrity": "sha512-2APKKruFNCAZgx3daAyACGzWuJ028VVCUDk6o2rw/Z4PXT0ogwdV4KUegW0MwVs0Zu59auPXbbuBJHF12Sx1Eg==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true
+    },
     "node_modules/@types/stylis": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.4.tgz",
@@ -2280,6 +2340,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.0.0.tgz",
+      "integrity": "sha512-/rxo+pzCFaUozK7TyCqo3GYwzdBGn9Ai6EsT8ytXDoUXlD/Q5hw9hj2lOkCAyubECzGJFHMmQg9GZ1GOGlN/qQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinon": "^10.0.10",
+        "sinon": "^16.1.3",
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -4293,6 +4364,12 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4329,6 +4406,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -4750,6 +4833,28 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/nise": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.9.tgz",
+      "integrity": "sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/text-encoding": "^0.7.2",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^6.2.1"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -5798,6 +5903,45 @@
         "ws": "^7.4.2"
       }
     },
+    "node_modules/sinon": {
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-16.1.3.tgz",
+      "integrity": "sha512-mjnWWeyxcAf9nC0bXcPmiDut+oE8HYridTNzBbF98AYVLmWwGRp2ISEpyhYflG1ifILT+eNn3BmKUJPxjXUPlA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^10.3.0",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.1.0",
+        "nise": "^5.1.4",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slugify": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.7.tgz",
@@ -6141,6 +6285,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -6247,9 +6400,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
-      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "dev": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@adobe/eslint-config-helix": "2.0.6",
     "@redocly/cli": "^1.4.1",
+    "aws-sdk-client-mock": "^4.0.0",
     "c8": "^8.0.1",
     "eslint": "8.56.0",
     "esmock": "^2.6.4",

--- a/src/helpers/source.js
+++ b/src/helpers/source.js
@@ -15,7 +15,7 @@ import { FORM_TYPES } from '../utils/constants.js';
  * Builds a source response
  * @param {*} key
  */
-export function sourceRespObject(daCtx, props) {
+export function sourceRespObject(daCtx) {
   const {
     org, site, isFile, pathname, aemPathname,
   } = daCtx;
@@ -26,8 +26,6 @@ export function sourceRespObject(daCtx, props) {
       contentUrl: `https://content.da.live/${org}${pathname}`,
     },
   };
-
-  if (props) obj.source.props = props;
 
   if (site) {
     obj.aem = {
@@ -46,10 +44,6 @@ function getFormEntries(formData) {
     entries.data = formData.get('data');
   }
 
-  if (formData.get('props')) {
-    entries.props = JSON.parse(formData.get('props'));
-  }
-
   return entries;
 }
 
@@ -59,7 +53,7 @@ async function formPutHandler(req) {
     formData = await req.formData();
   } catch (e) {
     // eslint-disable-next-line no-console
-    console.log('No form data', e);
+    console.log('No form data');
   }
   return formData ? getFormEntries(formData) : null;
 }
@@ -67,9 +61,9 @@ async function formPutHandler(req) {
 export default async function putHelper(req, env, daCtx) {
   const contentType = req.headers.get('content-type')?.split(';')[0];
 
-  if (FORM_TYPES.some((type) => type === contentType)) return formPutHandler(req, env, daCtx);
-
   if (!contentType) return null;
+
+  if (FORM_TYPES.some((type) => type === contentType)) return formPutHandler(req, env, daCtx);
 
   return undefined;
 }

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -66,10 +66,14 @@ export async function getUsers(req, env) {
 export async function isAuthorized(env, org, user) {
   if (!org) return true;
 
-  const props = await env.DA_AUTH.get(`${org}-da-props`, { type: 'json' });
+  const props = await env.DA_CONFIG.get(org, { type: 'json' });
   if (!props) return true;
 
-  const admins = props['admin.role.all'];
+  const admins = props.data.reduce((acc, data) => {
+    if (data.key === 'admin.role.all') acc.push(data.value);
+    return acc;
+  }, []);
+
   if (!admins) return true;
-  return admins.some((orgUser) => orgUser === user.email);
+  return admins.some((admin) => admin === user.email);
 }

--- a/test/helpers/source.test.js
+++ b/test/helpers/source.test.js
@@ -1,0 +1,63 @@
+import assert from 'assert';
+import putHelper from '../../src/helpers/source.js';
+
+import env from '../utils/mocks/env.js';
+const daCtx = { org: 'cq', key: 'geometrixx/hello.html', propsKey: 'geometrixx/hello.html.props' };
+
+const MOCK_URL = 'https://da.live/source/cq/geometrixx/hello';
+
+describe('Source helper', () => {
+  describe('Put success', async () => {
+    it('Returns null if no content type', async () => {
+      const req = new Request(MOCK_URL);
+
+      const helped = await putHelper(req, env, daCtx);
+      assert.strictEqual(helped, null);
+    });
+
+    it('Returns null if unssupported content type', async () => {
+      const opts = {
+        headers: new Headers({
+          'Content-Type': `custom/form; boundary`,
+        }),
+      };
+
+      const req = new Request(MOCK_URL, opts);
+
+      const helped = await putHelper(req, env, daCtx);
+      assert.strictEqual(helped, undefined);
+    });
+
+    it('Returns null if supported content type but no form data', async () => {
+      const opts = {
+        body: {},
+        method: 'PUT',
+        headers: new Headers({
+          'Content-Type': `multipart/form-data; boundary`,
+        }),
+      };
+
+      const req = new Request(MOCK_URL, opts);
+
+      const helped = await putHelper(req, env, daCtx);
+      assert.strictEqual(helped, null);
+    });
+
+    it('Returns empty object if no form data fields', async () => {
+      const body = new FormData();
+
+      const opts = {
+        body,
+        method: 'PUT',
+        headers: new Headers({
+          'Content-Type': `application/x-www-form-urlencoded; boundary`,
+        }),
+      };
+
+      const req = new Request(MOCK_URL, opts);
+
+      const helped = await putHelper(req, env, daCtx);
+      assert.strictEqual(Object.keys(helped).length, 0);
+    });
+  });
+});

--- a/test/storage/kv/kv.test.js
+++ b/test/storage/kv/kv.test.js
@@ -3,7 +3,18 @@ import assert from 'assert';
 import getKv from '../../../src/storage/kv/get.js';
 import putKv from '../../../src/storage/kv/put.js';
 
-const MOCK_CONFIG = '{"mock":"data"}';
+const MOCK_CONFIG = `{
+  "total": 1,
+  "limit": 1,
+  "offset": 0,
+  "data": [
+      {
+          "key": "admin.role.all",
+          "value": "aparker@geometrixx.info"
+      }
+  ],
+  ":type": "sheet"
+}`;
 
 describe('KV storage', () => {
   describe('Get success', async () => {

--- a/test/storage/object/mocks/version/put.js
+++ b/test/storage/object/mocks/version/put.js
@@ -1,0 +1,7 @@
+export async function postObjectVersion(env, daCtx) {
+  return 200;
+}
+
+export async function putObjectWithVersion(env, daCtx, update, body) {
+  return 201;
+}

--- a/test/storage/object/put.test.js
+++ b/test/storage/object/put.test.js
@@ -1,0 +1,47 @@
+import assert from 'assert';
+import { strict as esmock } from 'esmock';
+
+import env from '../../utils/mocks/env.js';
+
+import { mockClient } from 'aws-sdk-client-mock';
+import { S3Client } from '@aws-sdk/client-s3';
+
+const s3Mock = mockClient(S3Client);
+
+import { putObjectWithVersion, postObjectVersion } from './mocks/version/put.js';
+const putObject = await esmock('../../../src/storage/object/put.js', {
+  '../../../src/storage/version/put.js': {
+    putObjectWithVersion,
+    postObjectVersion,
+  }
+});
+
+describe('Object storage', () => {
+  beforeEach(() => {
+    s3Mock.reset();
+  });
+
+  describe('Put success', async () => {
+    it('Successfully puts text data', async () => {
+      const daCtx = { org: 'adobe', site: 'geometrixx', key: 'geometrixx', propsKey: 'geometrixx.props' };
+      const obj = { data: '<html></html>' };
+      const resp = await putObject(env, daCtx, obj);
+      assert.strictEqual(resp.status, 201);
+    });
+
+    it('Successfully puts file data', async () => {
+      const daCtx = { org: 'adobe', site: 'geometrixx', isFile: true, key: 'geometrixx/foo.html', pathname: '/foo', propsKey: 'geometrixx/foo.html.props' };
+      const data = new File(['foo'], 'foo.txt', { type: 'text/plain' });
+      const obj = { data };
+      const resp = await putObject(env, daCtx, obj);
+      assert.strictEqual(resp.status, 201);
+      assert.strictEqual(JSON.parse(resp.body).source.editUrl, 'https://da.live/edit#/adobe/foo')
+    });
+
+    it('Successfully puts no data', async () => {
+      const daCtx = { org: 'adobe', site: 'geometrixx', key: 'geometrixx', propsKey: 'geometrixx.props' };
+      const resp = await putObject(env, daCtx);
+      assert.strictEqual(resp.status, 201);
+    });
+  });
+});

--- a/test/utils/mocks/env.js
+++ b/test/utils/mocks/env.js
@@ -1,14 +1,41 @@
 const NAMESPACES = {
   'geometrixx-da-props': { "admin.role.all":["aparker@geometrixx.info"] },
   'beagle-da-props': { },
-}
+  'orgs': [
+    { name: 'geometrixx' },
+    { name: 'beagle' },
+  ]
+};
+const DA_CONFIG = {
+  'geometrixx': {
+    "total": 1,
+    "limit": 1,
+    "offset": 0,
+    "data": [
+        {
+            "key": "admin.role.all",
+            "value": "aparker@geometrixx.info"
+        }
+    ],
+    ":type": "sheet"
+  }
+};
 
 const env = {
+  S3_DEF_URL: 'https://s3.com',
+  S3_ACCESS_KEY_ID: 'an-id',
+  S3_SECRET_ACCESS_KEY: 'too-many-secrets',
   DA_AUTH: {
     get: (kvNamespace) => {
       return NAMESPACES[kvNamespace];
     },
     put: (kvNamespace, value, expObj) => {},
+  },
+  DA_CONFIG: {
+    get: (name) => {
+      return DA_CONFIG[name];
+    },
+    put: (name, value, expObj) => {},
   }
 };
 

--- a/test/utils/mocks/s3.js
+++ b/test/utils/mocks/s3.js
@@ -1,0 +1,9 @@
+class S3Client {
+
+}
+
+class PutObjectCommand {
+
+}
+
+export default S3Client;


### PR DESCRIPTION
* Ability to use `/config` to setup `admin.role.all`.
* Org performance improved by creating an `orgs` key (index) in DA_AUTH.
* Org / bucket check now only happens when org or repo is being POSTed. Middleware and index check / udpate will not be added if split path is longer than 2.

Resolves: GH-35

## How to test

1. Visit: https://main--da-live--adobe.hlx.page/?da-admin=stage
2. Notice faster listing of orgs (down from 2s+ to < 1s)
3. Select a test org
4. Select config icon in breadcrumb
5. Add:

```
key            | value
admin.role.all | youremail@youremail.com
```
Notice that if you re-visit (with the stage query param) in a private window, the org will not be visible.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Release notes
* Authentication is now self service using the config view.
* Org list performance improvements by creating an index. Cutting response times from 2.5s+ to ~500ms.