### PR TITLE
GH-6 Version Labels

### DIFF
--- a/src/handlers/post.js
+++ b/src/handlers/post.js
@@ -19,7 +19,7 @@ export default async function postHandler({ req, env, daCtx }) {
 
   if (path.startsWith('/source')) return postSource({ req, env, daCtx });
   if (path.startsWith('/config')) return postConfig({ req, env, daCtx });
-  if (path.startsWith('/versionsource')) return postVersionSource({ env, daCtx });
+  if (path.startsWith('/versionsource')) return postVersionSource({ req, env, daCtx });
   if (path.startsWith('/copy')) return copyHandler({ req, env, daCtx });
 
   return undefined;

--- a/src/routes/source.js
+++ b/src/routes/source.js
@@ -35,7 +35,7 @@ async function invalidateCollab(api, url, env) {
 }
 
 export async function deleteSource({ req, env, daCtx }) {
-  await postObjectVersion(env, daCtx);
+  await postObjectVersion(req, env, daCtx);
   const resp = await deleteObject(env, daCtx);
 
   if (resp.status === 204) {

--- a/src/routes/version.js
+++ b/src/routes/version.js
@@ -27,6 +27,6 @@ export async function patchVersion({ req, env, daCtx }) {
   return patchObjectVersion(req, env, daCtx);
 }
 
-export async function postVersionSource({ env, daCtx }) {
-  return postObjectVersion(env, daCtx);
+export async function postVersionSource({ req, env, daCtx }) {
+  return postObjectVersion(req, env, daCtx);
 }

--- a/src/storage/version/list.js
+++ b/src/storage/version/list.js
@@ -25,7 +25,7 @@ export async function listObjectVersions(env, { org, key }) {
     }, true);
     const timestamp = parseInt(entryResp.metadata.timestamp || '0', 10);
     const users = JSON.parse(entryResp.metadata.users || '[{"email":"anonymous"}]');
-    const { displayname, path } = entryResp.metadata;
+    const { comment, label, path } = entryResp.metadata;
 
     if (entryResp.contentLength > 0) {
       return {
@@ -33,7 +33,8 @@ export async function listObjectVersions(env, { org, key }) {
         users,
         timestamp,
         path,
-        displayname,
+        label,
+        comment,
       };
     }
     return { users, timestamp, path };

--- a/src/storage/version/list.js
+++ b/src/storage/version/list.js
@@ -25,7 +25,7 @@ export async function listObjectVersions(env, { org, key }) {
     }, true);
     const timestamp = parseInt(entryResp.metadata.timestamp || '0', 10);
     const users = JSON.parse(entryResp.metadata.users || '[{"email":"anonymous"}]');
-    const { comment, label, path } = entryResp.metadata;
+    const { label, path } = entryResp.metadata;
 
     if (entryResp.contentLength > 0) {
       return {
@@ -34,7 +34,6 @@ export async function listObjectVersions(env, { org, key }) {
         timestamp,
         path,
         label,
-        comment,
       };
     }
     return { users, timestamp, path };

--- a/src/storage/version/patch.js
+++ b/src/storage/version/patch.js
@@ -22,7 +22,7 @@ function buildInput({
   };
 }
 
-// Currently only patches the display name into the version
+// Currently only patches the label or comment into the version
 export async function patchObjectVersion(req, env, daCtx) {
   const rb = await req.json();
   const { org, key } = daCtx;
@@ -43,7 +43,8 @@ export async function patchObjectVersion(req, env, daCtx) {
       Users: current.metadata?.users || JSON.stringify([{ email: 'anonymous' }]),
       Timestamp: current.metadata?.timestamp || `${Date.now()}`,
       Path: current.metadata?.path || daCtx.key,
-      Displayname: rb.displayname,
+      Label: rb.label || current.metadata?.label,
+      Comment: rb.comment || current.metadata?.comment,
     },
   }, false);
   return { status: resp.status };

--- a/src/storage/version/patch.js
+++ b/src/storage/version/patch.js
@@ -22,7 +22,7 @@ function buildInput({
   };
 }
 
-// Currently only patches the label or comment into the version
+// Currently only patches the label into the version
 export async function patchObjectVersion(req, env, daCtx) {
   const rb = await req.json();
   const { org, key } = daCtx;
@@ -44,7 +44,6 @@ export async function patchObjectVersion(req, env, daCtx) {
       Timestamp: current.metadata?.timestamp || `${Date.now()}`,
       Path: current.metadata?.path || daCtx.key,
       Label: rb.label || current.metadata?.label,
-      Comment: rb.comment || current.metadata?.comment,
     },
   }, false);
   return { status: resp.status };

--- a/src/storage/version/put.js
+++ b/src/storage/version/put.js
@@ -50,7 +50,7 @@ export async function postObjectVersion(req, env, daCtx) {
   try {
     reqJSON = await req.json();
   } catch (e) {
-    // no label or comment
+    // no label
   }
 
   const config = getS3Config(env);
@@ -61,14 +61,13 @@ export async function postObjectVersion(req, env, daCtx) {
   }
 
   let existingVersion;
-  if (reqJSON?.label === undefined || reqJSON?.comment === undefined) {
+  if (reqJSON?.label === undefined) {
     existingVersion = await getObject(env, {
       org: daCtx.org,
       key: `.da-versions/${current.metadata.id}/${current.metadata.version}.${daCtx.ext}`,
     });
   }
   const label = reqJSON?.label || existingVersion?.metadata?.label;
-  const comment = reqJSON?.comment || existingVersion?.metadata?.comment;
 
   const resp = await putVersion(config, {
     Bucket: update.Bucket,
@@ -81,7 +80,6 @@ export async function postObjectVersion(req, env, daCtx) {
       Timestamp: current.metadata?.timestamp || `${Date.now()}`,
       Path: current.metadata?.path || daCtx.key,
       Label: label,
-      Comment: comment,
     },
   }, false);
   return { status: resp.status === 200 ? 201 : resp.status };

--- a/src/storage/version/put.js
+++ b/src/storage/version/put.js
@@ -46,12 +46,11 @@ function buildInput({
 }
 
 export async function postObjectVersion(req, env, daCtx) {
-  let displayName;
+  let reqJSON;
   try {
-    const json = await req.json();
-    displayName = json.displayname;
+    reqJSON = await req.json();
   } catch (e) {
-    // no display name
+    // no label or comment
   }
 
   const config = getS3Config(env);
@@ -70,7 +69,8 @@ export async function postObjectVersion(req, env, daCtx) {
       Users: current.metadata?.users || JSON.stringify([{ email: 'anonymous' }]),
       Timestamp: current.metadata?.timestamp || `${Date.now()}`,
       Path: current.metadata?.path || daCtx.key,
-      Displayname: displayName || current.metadata?.displayname,
+      Label: reqJSON?.label || current.metadata?.label,
+      Comment: reqJSON?.comment || current.metadata?.comment,
     },
   }, false);
   return { status: resp.status === 200 ? 201 : resp.status };

--- a/src/storage/version/put.js
+++ b/src/storage/version/put.js
@@ -45,7 +45,15 @@ function buildInput({
   };
 }
 
-export async function postObjectVersion(env, daCtx) {
+export async function postObjectVersion(req, env, daCtx) {
+  let displayName;
+  try {
+    const json = await req.json();
+    displayName = json.displayname;
+  } catch (e) {
+    // no display name
+  }
+
   const config = getS3Config(env);
   const update = buildInput(daCtx);
   const current = await getObject(env, daCtx);
@@ -62,6 +70,7 @@ export async function postObjectVersion(env, daCtx) {
       Users: current.metadata?.users || JSON.stringify([{ email: 'anonymous' }]),
       Timestamp: current.metadata?.timestamp || `${Date.now()}`,
       Path: current.metadata?.path || daCtx.key,
+      Displayname: displayName || current.metadata?.displayname,
     },
   }, false);
   return { status: resp.status === 200 ? 201 : resp.status };

--- a/test/storage/version/patch.test.js
+++ b/test/storage/version/patch.test.js
@@ -32,7 +32,7 @@ describe('Version Patch', () => {
   })
 
   it('Patch Object Version', async () => {
-    const req = { json: async () => JSON.parse('{"comment": "comment 1"}')};
+    const req = { json: async () => JSON.parse('{}')};
     const env = {
       S3_DEF_URL: 's3def',
       S3_ACCESS_KEY_ID: 'id',
@@ -101,7 +101,6 @@ describe('Version Patch', () => {
     assert.equal('999', de.Metadata.Timestamp);
     assert.equal('mykey', de.Metadata.Path);
     assert.equal('prev label', de.Metadata.Label);
-    assert.equal('comment 1', de.Metadata.Comment);
     assert.equal(200, resp.status);
   });
 

--- a/test/storage/version/patch.test.js
+++ b/test/storage/version/patch.test.js
@@ -14,7 +14,7 @@ import esmock from 'esmock';
 
 describe('Version Patch', () => {
   it('Patch Object unknown', async () => {
-    const req = { json: async () => JSON.parse('{"displayname": "Some version"}')};
+    const req = { json: async () => JSON.parse('{"label": "Some version"}')};
     const { patchObjectVersion } = await esmock(
       '../../../src/storage/version/patch.js', {
         '../../../src/storage/object/get.js': {
@@ -32,7 +32,7 @@ describe('Version Patch', () => {
   })
 
   it('Patch Object Version', async () => {
-    const req = { json: async () => JSON.parse('{"displayname": "Some version"}')};
+    const req = { json: async () => JSON.parse('{"comment": "comment 1"}')};
     const env = {
       S3_DEF_URL: 's3def',
       S3_ACCESS_KEY_ID: 'id',
@@ -54,7 +54,7 @@ describe('Version Patch', () => {
 
     const mockedObject = {
       body: 'obj body',
-      metadata: { timestamp: '999' }
+      metadata: { timestamp: '999', label: 'prev label' }
     };
     const mockGetObject = async (e, c) => {
       if (e === env
@@ -100,12 +100,13 @@ describe('Version Patch', () => {
     assert.equal('[{"email":"anonymous"}]', de.Metadata.Users);
     assert.equal('999', de.Metadata.Timestamp);
     assert.equal('mykey', de.Metadata.Path);
-    assert.equal('Some version', de.Metadata.Displayname);
+    assert.equal('prev label', de.Metadata.Label);
+    assert.equal('comment 1', de.Metadata.Comment);
     assert.equal(200, resp.status);
   });
 
   it('Patch Object Version 2', async () => {
-    const req = { json: async () => JSON.parse('{"displayname": "v999"}')};
+    const req = { json: async () => JSON.parse('{"label": "v999"}')};
     const env = {};
     const daCtx = {
       org: 'org2',
@@ -167,7 +168,7 @@ describe('Version Patch', () => {
     assert.equal('[{"email":"jbloggs@acme"},{"email":"ablah@halba"}]', de.Metadata.Users);
     assert.equal('12345', de.Metadata.Timestamp);
     assert.equal('goobar', de.Metadata.Path);
-    assert.equal('v999', de.Metadata.Displayname);
+    assert.equal('v999', de.Metadata.Label);
     assert.equal(200, resp.status);
   });
 });

--- a/test/storage/version/put.test.js
+++ b/test/storage/version/put.test.js
@@ -71,7 +71,6 @@ describe('Version Put', () => {
   it('Post Object Version 2', async () => {
     const mockGetObject = async () => {
       const metadata = {
-        comment: 'my comment',
         label: 'old label',
         id: 'idx',
         version: '456',
@@ -121,7 +120,6 @@ describe('Version Put', () => {
     assert.equal('someorg-content', input.Bucket);
     assert.equal('.da-versions/idx/456.html', input.Key);
     assert.equal('[{"email":"foo@acme.org"}]', input.Metadata.Users);
-    assert.equal('my comment', input.Metadata.Comment);
     assert.equal('old label', input.Metadata.Label);
     assert.equal(999, input.Metadata.Timestamp);
     assert.equal('/y/z', input.Metadata.Path);
@@ -132,7 +130,6 @@ describe('Version Put', () => {
       if (x.key === '.da-versions/idx/456.myext') {
         const mdver = {
           label: 'existing label',
-          comment: 'existing comment',
         };
         return { metadata: mdver };
       }
@@ -186,7 +183,6 @@ describe('Version Put', () => {
     assert.equal('.da-versions/idx/456.myext', input.Key);
     assert.equal('[{"email":"one@acme.org"},{"email":"two@acme.org"}]', input.Metadata.Users);
     assert.equal('existing label', input.Metadata.Label);
-    assert.equal('existing comment', input.Metadata.Comment);
     assert.equal('/y/z', input.Metadata.Path);
   });
 });

--- a/test/storage/version/put.test.js
+++ b/test/storage/version/put.test.js
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import assert from 'assert';
+import esmock from 'esmock';
+
+describe('Version Put', () => {
+  it('Put Object Version 2', async () => {
+    const mockGetObject = async () => {
+      const metadata = {
+        displayname: 'old displayname',
+        id: 'idx',
+        version: '456',
+        path: '/y/z',
+        timestamp: 999,
+        users: '[{"email":"foo@acme.org"}]',
+      }
+      return { metadata };
+    };
+
+    const sentToS3 = [];
+    const s3Client = {
+      send: async (c) => {
+        sentToS3.push(c);
+        return {
+          $metadata: {
+            httpStatusCode: 202
+          }
+        };
+      }
+    };
+    const mockS3Client = () => s3Client;
+
+    const { postObjectVersion } = await esmock('../../../src/storage/version/put.js', {
+      '../../../src/storage/object/get.js': {
+        default: mockGetObject
+      },
+      '../../../src/storage/utils/version.js': {
+        createBucketIfMissing: mockS3Client
+      },
+    });
+
+    const dn = { displayname: 'my display name' };
+    const req = {};
+    const env = {};
+    const daCtx = {
+      org: 'someorg',
+      key: '/a/b/c',
+      ext: 'html'
+    };
+
+    const resp = await postObjectVersion(req, env, daCtx);
+    assert.equal(202, resp.status);
+
+    assert.equal(1, sentToS3.length);
+    const input = sentToS3[0].input;
+    assert.equal('someorg-content', input.Bucket);
+    assert.equal('.da-versions/idx/456.html', input.Key);
+    assert.equal('[{"email":"foo@acme.org"}]', input.Metadata.Users);
+    assert.equal('old displayname', input.Metadata.Displayname);
+    assert.equal(999, input.Metadata.Timestamp);
+    assert.equal('/y/z', input.Metadata.Path);
+  });
+
+  it('Put Object Version', async () => {
+    const mockGetObject = async () => {
+      const metadata = {
+        id: 'id',
+        version: '123'
+      }
+      return { metadata };
+    };
+
+    const sentToS3 = [];
+    const s3Client = {
+      send: async (c) => {
+        sentToS3.push(c);
+        return {
+          $metadata: {
+            httpStatusCode: 200
+          }
+        };
+      }
+    };
+    const mockS3Client = () => s3Client;
+
+    const { postObjectVersion } = await esmock('../../../src/storage/version/put.js', {
+      '../../../src/storage/object/get.js': {
+        default: mockGetObject
+      },
+      '../../../src/storage/utils/version.js': {
+        createBucketIfMissing: mockS3Client
+      },
+    });
+
+    const dn = { displayname: 'my display name' };
+    const req = {
+      json: async () => dn
+    };
+    const env = {};
+    const daCtx = {
+      org: 'myorg',
+      key: '/a/b/c',
+      ext: 'html'
+    };
+
+    const resp = await postObjectVersion(req, env, daCtx);
+    assert.equal(201, resp.status);
+
+    assert.equal(1, sentToS3.length);
+    const input = sentToS3[0].input;
+    assert.equal('myorg-content', input.Bucket);
+    assert.equal('.da-versions/id/123.html', input.Key);
+    assert.equal('[{"email":"anonymous"}]', input.Metadata.Users);
+    assert.equal('my display name', input.Metadata.Displayname);
+    assert(input.Metadata.Timestamp > (Date.now() - 2000)); // Less than 2 seconds old
+    assert.equal('/a/b/c', input.Metadata.Path);
+  });
+});

--- a/test/storage/version/put.test.js
+++ b/test/storage/version/put.test.js
@@ -44,7 +44,7 @@ describe('Version Put', () => {
       },
     });
 
-    const dn = { displayname: 'my display name' };
+    const dn = { label: 'my label' };
     const req = {
       json: async () => dn
     };
@@ -63,7 +63,7 @@ describe('Version Put', () => {
     assert.equal('myorg-content', input.Bucket);
     assert.equal('.da-versions/id/123.html', input.Key);
     assert.equal('[{"email":"anonymous"}]', input.Metadata.Users);
-    assert.equal('my display name', input.Metadata.Displayname);
+    assert.equal('my label', input.Metadata.Label);
     assert(input.Metadata.Timestamp > (Date.now() - 2000)); // Less than 2 seconds old
     assert.equal('/a/b/c', input.Metadata.Path);
   });
@@ -71,7 +71,8 @@ describe('Version Put', () => {
   it('Put Object Version 2', async () => {
     const mockGetObject = async () => {
       const metadata = {
-        displayname: 'old displayname',
+        comment: 'my comment',
+        label: 'old label',
         id: 'idx',
         version: '456',
         path: '/y/z',
@@ -103,7 +104,7 @@ describe('Version Put', () => {
       },
     });
 
-    const dn = { displayname: 'my display name' };
+    const dn = { label: 'my label' };
     const req = {};
     const env = {};
     const daCtx = {
@@ -120,7 +121,8 @@ describe('Version Put', () => {
     assert.equal('someorg-content', input.Bucket);
     assert.equal('.da-versions/idx/456.html', input.Key);
     assert.equal('[{"email":"foo@acme.org"}]', input.Metadata.Users);
-    assert.equal('old displayname', input.Metadata.Displayname);
+    assert.equal('my comment', input.Metadata.Comment);
+    assert.equal('old label', input.Metadata.Label);
     assert.equal(999, input.Metadata.Timestamp);
     assert.equal('/y/z', input.Metadata.Path);
   });


### PR DESCRIPTION
## Description

Make it possible to provide a version display name on the initial version POST/PUT.

## Related Issue

#6

## How Has This Been Tested?

* Tested locally with da-collab and da-live
* Unit tests for all changes


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Release notes

1. Ability to add a label to a version upon creation.

## Additional context
Version labels provide a humane context to what a version represents. They can also be helpful for larger larger content projects. Changes happen over a series of days, weeks, or even months. This disjointed nature of content creation makes snapshot-style versions difficult to impossible to use. Being able to label versions provides a way to say in human terms, "rollback to a pre-Adobe MAX 2024 state."

DA Admin is built on top of object storage technologies. This provides a no-nonsense approach to data storage, but it lacks the granular nature of something like a NoSQL database. Object storage metadata is also immutable. What this effectively means is that if you want to update metadata, you must re-write the entire file. Moving version label creation to the POST handler ensures that we can perform one operation to create the version and label.