### PR TITLE
Store version content automatically once in preparation for parsing change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "eslint": "8.56.0",
         "esmock": "^2.6.4",
         "mocha": "^10.2.0",
-        "wrangler": "^3.55.0"
+        "wrangler": "^3.57.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -940,9 +940,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20240419.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20240419.0.tgz",
-      "integrity": "sha512-PGVe9sYWULHfvGhN0IZh8MsskNG/ufnBSqPbgFCxJHCTrVXLPuC35EoVaforyqjKRwj3U35XMyGo9KHcGnTeHQ==",
+      "version": "1.20240512.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20240512.0.tgz",
+      "integrity": "sha512-VMp+CsSHFALQiBzPdQ5dDI4T1qwLu0mQ0aeKVNDosXjueN0f3zj/lf+mFil5/9jBbG3t4mG0y+6MMnalP9Lobw==",
       "cpu": [
         "x64"
       ],
@@ -956,9 +956,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20240419.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20240419.0.tgz",
-      "integrity": "sha512-z4etQSPiD5Gcjs962LiC7ZdmXnN6SGof5KrYoFiSI9X9kUvpuGH/lnjVVPd+NnVNeDU2kzmcAIgyZjkjTaqVXQ==",
+      "version": "1.20240512.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20240512.0.tgz",
+      "integrity": "sha512-lZktXGmzMrB5rJqY9+PmnNfv1HKlj/YLZwMjPfF0WVKHUFdvQbAHsi7NlKv6mW9uIvlZnS+K4sIkWc0MDXcRnA==",
       "cpu": [
         "arm64"
       ],
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20240419.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20240419.0.tgz",
-      "integrity": "sha512-lBwhg0j3sYTFMsEb4bOClbVje8nqrYOu0H3feQlX+Eks94JIhWPkf8ywK4at/BUc1comPMhCgzDHwc2OMPUGgg==",
+      "version": "1.20240512.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20240512.0.tgz",
+      "integrity": "sha512-wrHvqCZZqXz6Y3MUTn/9pQNsvaoNjbJpuA6vcXsXu8iCzJi911iVW2WUEBX+MpUWD+mBIP0oXni5tTlhkokOPw==",
       "cpu": [
         "x64"
       ],
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20240419.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20240419.0.tgz",
-      "integrity": "sha512-ZMY6wwWkxL+WPq8ydOp/irSYjAnMhBz1OC1+4z+OANtDs2beaZODmq7LEB3hb5WUAaTPY7DIjZh3DfDfty0nYg==",
+      "version": "1.20240512.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20240512.0.tgz",
+      "integrity": "sha512-YPezHMySL9J9tFdzxz390eBswQ//QJNYcZolz9Dgvb3FEfdpK345cE/bsWbMOqw5ws2f82l388epoenghtYvAg==",
       "cpu": [
         "arm64"
       ],
@@ -1004,9 +1004,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20240419.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20240419.0.tgz",
-      "integrity": "sha512-YJjgaJN2yGTkV7Cr4K3i8N4dUwVQTclT3Pr3NpRZCcLjTszwlE53++XXDnHMKGXBbSguIizaVbmcU2EtmIXyeQ==",
+      "version": "1.20240512.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20240512.0.tgz",
+      "integrity": "sha512-SxKapDrIYSscMR7lGIp/av0l6vokjH4xQ9ACxHgXh+OdOus9azppSmjaPyw4/ePvg7yqpkaNjf9o258IxWtvKQ==",
       "cpu": [
         "x64"
       ],
@@ -4593,9 +4593,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "3.20240419.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20240419.1.tgz",
-      "integrity": "sha512-Q9n0W07uUD/u0c/b03E4iogeXOAMjZnE3P7B5Yi8sPaZAx6TYWwjurGBja+Pg2yILN2iMaliEobfVyAKss33cA==",
+      "version": "3.20240512.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20240512.0.tgz",
+      "integrity": "sha512-X0PlKR0AROKpxFoJNmRtCMIuJxj+ngEcyTOlEokj2rAQ0TBwUhB4/1uiPvdI6ofW5NugPOD1uomAv+gLjwsLDQ==",
       "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
@@ -4606,7 +4606,7 @@
         "glob-to-regexp": "^0.4.1",
         "stoppable": "^1.1.0",
         "undici": "^5.28.2",
-        "workerd": "1.20240419.0",
+        "workerd": "1.20240512.0",
         "ws": "^8.11.0",
         "youch": "^3.2.2",
         "zod": "^3.20.6"
@@ -6594,9 +6594,9 @@
       "dev": true
     },
     "node_modules/workerd": {
-      "version": "1.20240419.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20240419.0.tgz",
-      "integrity": "sha512-9yV98KpkQgG+bdEsKEW8i1AYZgxns6NVSfdOVEB2Ue1pTMtIEYfUyqUE+O2amisRrfaC3Pw4EvjtTmVaoetfeg==",
+      "version": "1.20240512.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20240512.0.tgz",
+      "integrity": "sha512-VUBmR1PscAPHEE0OF/G2K7/H1gnr9aDWWZzdkIgWfNKkv8dKFCT75H+GJtUHjfwqz3rYCzaNZmatSXOpLGpF8A==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -6606,11 +6606,11 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20240419.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20240419.0",
-        "@cloudflare/workerd-linux-64": "1.20240419.0",
-        "@cloudflare/workerd-linux-arm64": "1.20240419.0",
-        "@cloudflare/workerd-windows-64": "1.20240419.0"
+        "@cloudflare/workerd-darwin-64": "1.20240512.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20240512.0",
+        "@cloudflare/workerd-linux-64": "1.20240512.0",
+        "@cloudflare/workerd-linux-arm64": "1.20240512.0",
+        "@cloudflare/workerd-windows-64": "1.20240512.0"
       }
     },
     "node_modules/workerpool": {
@@ -6620,9 +6620,9 @@
       "dev": true
     },
     "node_modules/wrangler": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.55.0.tgz",
-      "integrity": "sha512-VhtCioKxOdVqkHa8jQ6C6bX3by2Ko0uM0DKzrA+6lBZvfDUlGDWSOPiG+1fOHBHj2JTVBntxWCztXP6L+Udr8w==",
+      "version": "3.57.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.57.0.tgz",
+      "integrity": "sha512-izK3AZtlFoTq8N0EZjLOQ7hqwsjaXCc1cbNKuhsLJjDX1jB1YZBDPhIhtXL4VVzkJAcH+0Zw2gguOePFCHNaxw==",
       "dev": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.3.2",
@@ -6631,7 +6631,7 @@
         "blake3-wasm": "^2.1.5",
         "chokidar": "^3.5.3",
         "esbuild": "0.17.19",
-        "miniflare": "3.20240419.1",
+        "miniflare": "3.20240512.0",
         "nanoid": "^3.3.3",
         "path-to-regexp": "^6.2.0",
         "resolve": "^1.22.8",
@@ -6651,7 +6651,7 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20240419.0"
+        "@cloudflare/workers-types": "^4.20240512.0"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "eslint": "8.56.0",
         "esmock": "^2.6.4",
         "mocha": "^10.2.0",
-        "wrangler": "^3.17.1"
+        "wrangler": "^3.55.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -928,18 +928,37 @@
       "dev": true
     },
     "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.2.0.tgz",
-      "integrity": "sha512-MVbXLbTcAotOPUj0pAMhVtJ+3/kFkwJqc5qNOleOZTv6QkZZABDMS21dSrSlVswEHwrpWC03e4fWytjqKvuE2A==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.2.tgz",
+      "integrity": "sha512-EeEjMobfuJrwoctj7FA1y1KEbM0+Q1xSjobIEyie9k4haVEBB7vkDvsasw1pM3rO39mL2akxIAzLMUAtrMHZhA==",
       "dev": true,
       "dependencies": {
         "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20240419.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20240419.0.tgz",
+      "integrity": "sha512-PGVe9sYWULHfvGhN0IZh8MsskNG/ufnBSqPbgFCxJHCTrVXLPuC35EoVaforyqjKRwj3U35XMyGo9KHcGnTeHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20240129.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20240129.0.tgz",
-      "integrity": "sha512-t0q8ABkmumG1zRM/MZ/vIv/Ysx0vTAXnQAPy/JW5aeQi/tqrypXkO9/NhPc0jbF/g/hIPrWEqpDgEp3CB7Da7Q==",
+      "version": "1.20240419.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20240419.0.tgz",
+      "integrity": "sha512-z4etQSPiD5Gcjs962LiC7ZdmXnN6SGof5KrYoFiSI9X9kUvpuGH/lnjVVPd+NnVNeDU2kzmcAIgyZjkjTaqVXQ==",
       "cpu": [
         "arm64"
       ],
@@ -947,6 +966,54 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20240419.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20240419.0.tgz",
+      "integrity": "sha512-lBwhg0j3sYTFMsEb4bOClbVje8nqrYOu0H3feQlX+Eks94JIhWPkf8ywK4at/BUc1comPMhCgzDHwc2OMPUGgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20240419.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20240419.0.tgz",
+      "integrity": "sha512-ZMY6wwWkxL+WPq8ydOp/irSYjAnMhBz1OC1+4z+OANtDs2beaZODmq7LEB3hb5WUAaTPY7DIjZh3DfDfty0nYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20240419.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20240419.0.tgz",
+      "integrity": "sha512-YJjgaJN2yGTkV7Cr4K3i8N4dUwVQTclT3Pr3NpRZCcLjTszwlE53++XXDnHMKGXBbSguIizaVbmcU2EtmIXyeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=16"
@@ -1118,9 +1185,9 @@
       "dev": true
     },
     "node_modules/@fastify/busboy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "dev": true,
       "engines": {
         "node": ">=14"
@@ -4526,9 +4593,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "3.20240129.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20240129.0.tgz",
-      "integrity": "sha512-27pDhlP2G/4gXmvnSt6LjMQ8KrkmbJElIQmn+BLjdiyIx+zXY4E8MSPJmi9flgf0dn3wtjuHO2ASenuopqqxrw==",
+      "version": "3.20240419.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20240419.1.tgz",
+      "integrity": "sha512-Q9n0W07uUD/u0c/b03E4iogeXOAMjZnE3P7B5Yi8sPaZAx6TYWwjurGBja+Pg2yILN2iMaliEobfVyAKss33cA==",
       "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
@@ -4539,7 +4606,7 @@
         "glob-to-regexp": "^0.4.1",
         "stoppable": "^1.1.0",
         "undici": "^5.28.2",
-        "workerd": "1.20240129.0",
+        "workerd": "1.20240419.0",
         "ws": "^8.11.0",
         "youch": "^3.2.2",
         "zod": "^3.20.6"
@@ -4552,9 +4619,9 @@
       }
     },
     "node_modules/miniflare/node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -6527,9 +6594,9 @@
       "dev": true
     },
     "node_modules/workerd": {
-      "version": "1.20240129.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20240129.0.tgz",
-      "integrity": "sha512-t4pnsmjjk/u+GdVDgH2M1AFmJaBUABshYK/vT/HNrAXsHSwN6VR8Yqw0JQ845OokO34VLkuUtYQYyxHHKpdtsw==",
+      "version": "1.20240419.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20240419.0.tgz",
+      "integrity": "sha512-9yV98KpkQgG+bdEsKEW8i1AYZgxns6NVSfdOVEB2Ue1pTMtIEYfUyqUE+O2amisRrfaC3Pw4EvjtTmVaoetfeg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -6539,11 +6606,11 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20240129.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20240129.0",
-        "@cloudflare/workerd-linux-64": "1.20240129.0",
-        "@cloudflare/workerd-linux-arm64": "1.20240129.0",
-        "@cloudflare/workerd-windows-64": "1.20240129.0"
+        "@cloudflare/workerd-darwin-64": "1.20240419.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20240419.0",
+        "@cloudflare/workerd-linux-64": "1.20240419.0",
+        "@cloudflare/workerd-linux-arm64": "1.20240419.0",
+        "@cloudflare/workerd-windows-64": "1.20240419.0"
       }
     },
     "node_modules/workerpool": {
@@ -6553,18 +6620,18 @@
       "dev": true
     },
     "node_modules/wrangler": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.26.0.tgz",
-      "integrity": "sha512-2FKDyL0wV6ws+9AHkQl5/Yzn17kG9jlpgyT7wqCDkhb5q+TCL/I8N5IKVwXe8tRrTluBI1QQZRRymoA5nu0pHw==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.55.0.tgz",
+      "integrity": "sha512-VhtCioKxOdVqkHa8jQ6C6bX3by2Ko0uM0DKzrA+6lBZvfDUlGDWSOPiG+1fOHBHj2JTVBntxWCztXP6L+Udr8w==",
       "dev": true,
       "dependencies": {
-        "@cloudflare/kv-asset-handler": "^0.2.0",
+        "@cloudflare/kv-asset-handler": "0.3.2",
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
         "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
         "blake3-wasm": "^2.1.5",
         "chokidar": "^3.5.3",
         "esbuild": "0.17.19",
-        "miniflare": "3.20240129.0",
+        "miniflare": "3.20240419.1",
         "nanoid": "^3.3.3",
         "path-to-regexp": "^6.2.0",
         "resolve": "^1.22.8",
@@ -6582,6 +6649,14 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20240419.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
       }
     },
     "node_modules/wrap-ansi": {
@@ -6730,9 +6805,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint": "8.56.0",
     "esmock": "^2.6.4",
     "mocha": "^10.2.0",
-    "wrangler": "^3.55.0"
+    "wrangler": "^3.57.0"
   },
   "lint-staged": {
     "*.js": "eslint",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint": "8.56.0",
     "esmock": "^2.6.4",
     "mocha": "^10.2.0",
-    "wrangler": "^3.17.1"
+    "wrangler": "^3.55.0"
   },
   "lint-staged": {
     "*.js": "eslint",

--- a/src/storage/object/put.js
+++ b/src/storage/object/put.js
@@ -85,11 +85,13 @@ export default async function putObject(env, daCtx, obj) {
   let status = 201;
   if (obj) {
     if (obj.data) {
+      const storeBody = (Date.now() % 20 === 0);
+
       const isFile = obj.data instanceof File;
       const { body, type } = isFile ? await getFileBody(obj.data) : getObjectBody(obj.data);
       status = await putObjectWithVersion(env, daCtx, {
         org, key, body, type,
-      });
+      }, storeBody);
     }
   } else {
     const { body, type } = getObjectBody({});

--- a/src/storage/object/put.js
+++ b/src/storage/object/put.js
@@ -85,13 +85,11 @@ export default async function putObject(env, daCtx, obj) {
   let status = 201;
   if (obj) {
     if (obj.data) {
-      const storeBody = (Date.now() % 20 === 0);
-
       const isFile = obj.data instanceof File;
       const { body, type } = isFile ? await getFileBody(obj.data) : getObjectBody(obj.data);
       status = await putObjectWithVersion(env, daCtx, {
         org, key, body, type,
-      }, storeBody);
+      }, true);
     }
   } else {
     const { body, type } = getObjectBody({});

--- a/src/storage/version/put.js
+++ b/src/storage/version/put.js
@@ -120,6 +120,7 @@ export async function putObjectWithVersion(env, daCtx, update, body) {
   // Store the body if preparsingstore is not defined, so a once-off store
   const storeBody = body && pps === '0';
   const Preparsingstore = storeBody ? Timestamp : pps;
+  const Label = storeBody ? 'Collab Parse' : undefined;
 
   const versionResp = await putVersion(config, {
     Bucket: input.Bucket,
@@ -131,6 +132,7 @@ export async function putObjectWithVersion(env, daCtx, update, body) {
       Users: current.metadata?.users || JSON.stringify([{ email: 'anonymous' }]),
       Timestamp: current.metadata?.timestamp || Timestamp,
       Path: current.metadata?.path || Path,
+      Label,
     },
   });
 

--- a/src/storage/version/put.js
+++ b/src/storage/version/put.js
@@ -115,11 +115,11 @@ export async function putObjectWithVersion(env, daCtx, update, body) {
     }
   }
 
-  const lfs = current.metadata?.lastfullstore || '0';
+  const pps = current.metadata?.preparsingstore || '0';
 
-  // Store only if we requested the body and the last full store was more than an hour ago
-  const storeBody = body && (Date.now() - lfs > 1000 * 60 * 60);
-  const Lastfullstore = storeBody ? Timestamp : lfs;
+  // Store the body if preparsingstore is not defined, so a once-off store
+  const storeBody = body && pps === '0';
+  const Preparsingstore = storeBody ? Timestamp : pps;
 
   const versionResp = await putVersion(config, {
     Bucket: input.Bucket,
@@ -142,7 +142,7 @@ export async function putObjectWithVersion(env, daCtx, update, body) {
   const command = new PutObjectCommand({
     ...input,
     Metadata: {
-      ID, Version: crypto.randomUUID(), Users, Timestamp, Path, Lastfullstore,
+      ID, Version: crypto.randomUUID(), Users, Timestamp, Path, Preparsingstore,
     },
   });
   try {

--- a/src/storage/version/put.js
+++ b/src/storage/version/put.js
@@ -89,25 +89,19 @@ export async function putObjectWithVersion(env, daCtx, update, body) {
   const config = getS3Config(env);
   const current = await getObject(env, update, !body);
 
-  const lfs = current.metadata?.lastfullstore || 0;
-
-  // Store only if we requested the body and the last full store was more than an hour ago
-  const storeBody = body && (Date.now() - lfs > 1000 * 60 * 60);
-
   const ID = current.metadata?.id || crypto.randomUUID();
   const Version = current.metadata?.version || crypto.randomUUID();
   const Users = JSON.stringify(daCtx.users);
   const input = buildInput(update);
   const Timestamp = `${Date.now()}`;
   const Path = update.key;
-  const Lastfullstore = storeBody ? Timestamp : lfs;
 
   if (current.status === 404) {
     const client = ifNoneMatch(config);
     const command = new PutObjectCommand({
       ...input,
       Metadata: {
-        ID, Version, Users, Timestamp, Path, Lastfullstore,
+        ID, Version, Users, Timestamp, Path,
       },
     });
     try {
@@ -121,9 +115,15 @@ export async function putObjectWithVersion(env, daCtx, update, body) {
     }
   }
 
+  const lfs = current.metadata?.lastfullstore || '0';
+
+  // Store only if we requested the body and the last full store was more than an hour ago
+  const storeBody = body && (Date.now() - lfs > 1000 * 60 * 60);
+  const Lastfullstore = storeBody ? Timestamp : lfs;
+
   const versionResp = await putVersion(config, {
     Bucket: input.Bucket,
-    Body: storeBody ? current.body : '',
+    Body: (storeBody ? current.body : ''),
     ID,
     Version,
     Ext: daCtx.ext,

--- a/test/storage/version/put.test.js
+++ b/test/storage/version/put.test.js
@@ -185,4 +185,183 @@ describe('Version Put', () => {
     assert.equal('existing label', input.Metadata.Label);
     assert.equal('/y/z', input.Metadata.Path);
   });
+
+  it('Put Object With Version store content', async () => {
+    const mockGetObject = async (e, u, h) => {
+      if (!h) {
+        return {
+          body: 'prevbody',
+          metadata: {
+            id: 'x123',
+            version: 'aaa-bbb',
+          },
+          status: 200
+        };
+      }
+    }
+
+    const s3VersionSent = [];
+    const mockS3VersionClient = {
+      send: (c) => {
+        s3VersionSent.push(c);
+        return { $metadata: { httpStatusCode: 200 } };
+      }
+    };
+    const mockIfNoneMatch = () => mockS3VersionClient;
+
+    const s3Sent = [];
+    const mockS3Client = {
+      send: (c) => {
+        s3Sent.push(c);
+        return { $metadata: { httpStatusCode: 200 } };
+      }
+    };
+    const mockIfMatch = () => mockS3Client
+
+    const { putObjectWithVersion } = await esmock('../../../src/storage/version/put.js', {
+      '../../../src/storage/object/get.js': {
+        default: mockGetObject
+      },
+      '../../../src/storage/utils/version.js': {
+        ifNoneMatch: mockIfNoneMatch,
+        ifMatch: mockIfMatch,
+      },
+    });
+
+    const env = {};
+    const daCtx= { ext: 'html' };
+    const update = { body: 'new-body', org: 'myorg', key: '/a/x.html' };
+    const resp = await putObjectWithVersion(env, daCtx, update, true);
+    assert.equal(200, resp);
+    assert.equal(1, s3VersionSent.length);
+    assert.equal('prevbody', s3VersionSent[0].input.Body);
+    assert.equal('myorg-content', s3VersionSent[0].input.Bucket);
+    assert.equal('.da-versions/x123/aaa-bbb.html', s3VersionSent[0].input.Key);
+    assert.equal('[{"email":"anonymous"}]', s3VersionSent[0].input.Metadata.Users);
+    assert.equal('/a/x.html', s3VersionSent[0].input.Metadata.Path);
+    assert(s3VersionSent[0].input.Metadata.Timestamp > 0);
+
+    assert.equal(1, s3Sent.length);
+    assert.equal('new-body', s3Sent[0].input.Body);
+    assert.equal('myorg-content', s3Sent[0].input.Bucket);
+    assert.equal('/a/x.html', s3Sent[0].input.Key);
+    assert.equal('x123', s3Sent[0].input.Metadata.ID);
+    assert.equal('/a/x.html', s3Sent[0].input.Metadata.Path);
+    assert.notEqual('aaa-bbb', s3Sent[0].input.Metadata.Version);
+    assert(s3Sent[0].input.Metadata.Timestamp > 0);
+    assert.equal(s3Sent[0].input.Metadata.Lastfullstore, s3Sent[0].input.Metadata.Timestamp);
+  });
+
+  it('Put Object With Version don\'t store content', async () => {
+    const mockGetObject = async (e, u, h) => {
+      if (!h) {
+        return {
+          body: 'prevbody',
+          metadata: {
+            id: 'q123-456',
+            lastfullstore: Date.now(),
+            version: 'ver123',
+          },
+          status: 201
+        };
+      }
+    }
+
+    const s3VersionSent = [];
+    const mockS3VersionClient = {
+      send: (c) => {
+        s3VersionSent.push(c);
+        return { $metadata: { httpStatusCode: 200 } };
+      }
+    };
+    const mockIfNoneMatch = () => mockS3VersionClient;
+
+    const s3Sent = [];
+    const mockS3Client = {
+      send: (c) => {
+        s3Sent.push(c);
+        return { $metadata: { httpStatusCode: 202 } };
+      }
+    };
+    const mockIfMatch = () => mockS3Client
+
+    const { putObjectWithVersion } = await esmock('../../../src/storage/version/put.js', {
+      '../../../src/storage/object/get.js': {
+        default: mockGetObject
+      },
+      '../../../src/storage/utils/version.js': {
+        ifNoneMatch: mockIfNoneMatch,
+        ifMatch: mockIfMatch,
+      },
+    });
+
+    const env = {};
+    const daCtx= { ext: 'html', users: [{"email": "foo@acme.org"}, {"email": "bar@acme.org"}] };
+    const update = { body: 'new-body', org: 'myorg', key: '/a/x.html' };
+    const resp = await putObjectWithVersion(env, daCtx, update, true);
+    assert.equal(202, resp);
+    assert.equal(1, s3VersionSent.length);
+    assert.equal('', s3VersionSent[0].input.Body);
+    assert.equal('myorg-content', s3VersionSent[0].input.Bucket);
+    assert.equal('.da-versions/q123-456/ver123.html', s3VersionSent[0].input.Key);
+    assert.equal('[{"email":"anonymous"}]', s3VersionSent[0].input.Metadata.Users);
+    assert.equal('/a/x.html', s3VersionSent[0].input.Metadata.Path);
+    assert(s3VersionSent[0].input.Metadata.Timestamp > 0);
+
+    assert.equal(1, s3Sent.length);
+    assert.equal('new-body', s3Sent[0].input.Body);
+    assert.equal('myorg-content', s3Sent[0].input.Bucket);
+    assert.equal('/a/x.html', s3Sent[0].input.Key);
+    assert.equal('q123-456', s3Sent[0].input.Metadata.ID);
+    assert.equal('/a/x.html', s3Sent[0].input.Metadata.Path);
+    assert.equal('[{\"email\":\"foo@acme.org\"},{\"email\":\"bar@acme.org\"}]', s3Sent[0].input.Metadata.Users);
+    assert.notEqual('aaa-bbb', s3Sent[0].input.Metadata.Version);
+    assert(s3Sent[0].input.Metadata.Timestamp > 0);
+    assert.equal(s3Sent[0].input.Metadata.Lastfullstore, s3Sent[0].input.Metadata.Timestamp);
+  });
+
+  it('Put First Object With Version', async () => {
+    const mockGetObject = async (e, u, h) => {
+      if (!h) {
+        return {
+          status: 404
+        };
+      }
+    }
+
+    const s3Sent = [];
+    const mockS3Client = {
+      send: (c) => {
+        s3Sent.push(c);
+        return {
+          $metadata: {
+            httpStatusCode: 200
+          }
+        };
+      }
+    };
+    const mockIfNoneMatch = () => mockS3Client;
+
+    const { putObjectWithVersion } = await esmock('../../../src/storage/version/put.js', {
+      '../../../src/storage/object/get.js': {
+        default: mockGetObject
+      },
+      '../../../src/storage/utils/version.js': {
+        ifNoneMatch: mockIfNoneMatch
+      },
+    });
+
+    const env = {};
+    const daCtx= {};
+    const update = { org: 'myorg', key: '/a/b/c' };
+    const resp = await putObjectWithVersion(env, daCtx, update, true);
+    assert.equal(201, resp);
+
+    assert.equal(1, s3Sent.length);
+    assert.equal('myorg-content', s3Sent[0].input.Bucket);
+    assert(s3Sent[0].input.Metadata.ID);
+    assert.equal('/a/b/c', s3Sent[0].input.Metadata.Path);
+    assert(s3Sent[0].input.Metadata.Timestamp > 0);
+    assert(s3Sent[0].input.Metadata.Version);
+  });
 });

--- a/test/storage/version/put.test.js
+++ b/test/storage/version/put.test.js
@@ -249,7 +249,7 @@ describe('Version Put', () => {
     assert.equal('/a/x.html', s3Sent[0].input.Metadata.Path);
     assert.notEqual('aaa-bbb', s3Sent[0].input.Metadata.Version);
     assert(s3Sent[0].input.Metadata.Timestamp > 0);
-    assert.equal(s3Sent[0].input.Metadata.Lastfullstore, s3Sent[0].input.Metadata.Timestamp);
+    assert.equal(s3Sent[0].input.Metadata.Preparsingstore, s3Sent[0].input.Metadata.Timestamp);
   });
 
   it('Put Object With Version don\'t store content', async () => {
@@ -259,7 +259,7 @@ describe('Version Put', () => {
           body: 'prevbody',
           metadata: {
             id: 'q123-456',
-            lastfullstore: Date.now(),
+            preparsingstore: Date.now(),
             version: 'ver123',
           },
           status: 201
@@ -317,7 +317,7 @@ describe('Version Put', () => {
     assert.equal('[{\"email\":\"foo@acme.org\"},{\"email\":\"bar@acme.org\"}]', s3Sent[0].input.Metadata.Users);
     assert.notEqual('aaa-bbb', s3Sent[0].input.Metadata.Version);
     assert(s3Sent[0].input.Metadata.Timestamp > 0);
-    assert.equal(s3Sent[0].input.Metadata.Lastfullstore, s3Sent[0].input.Metadata.Timestamp);
+    assert.equal(s3Sent[0].input.Metadata.Preparsingstore, s3Sent[0].input.Metadata.Timestamp);
   });
 
   it('Put First Object With Version', async () => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,6 +15,11 @@ kv_namespaces = [
 
 [env.stage]
 vars = { ENVIRONMENT = "stage", DA_COLLAB = "https://collab.da.live" }
+
+services = [
+  { binding = "dacollab", service = "da-collab-stage" }
+]
+
 kv_namespaces = [
   { binding = "DA_AUTH", id = "21693f3b20f54fcbb850ddc8947335ba" },
   { binding = "DA_CONFIG", id = "c44cb8dc69f041dc87c5aaef41b97df9" }


### PR DESCRIPTION
## Description

In preparation for the parsing changes coming to da-collab https://github.com/adobe/da-collab/pull/38 and da-live https://github.com/adobe/da-collab/pull/38 store the content of a document automatically once.

## Related Issue

#6 

## Motivation and Context

Right now versions are only stored when a user explicitly requests this.

## How Has This Been Tested?

Locally with da-live and da-collab. 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
