### PR TITLE
Support Authenticated Buckets/Orgs

### DIFF
--- a/src/handlers/get.js
+++ b/src/handlers/get.js
@@ -13,6 +13,7 @@ import { getSource } from '../routes/source.js';
 import getList from '../routes/list.js';
 import { getConfig } from '../routes/config.js';
 import { getVersionSource, getVersionList } from '../routes/version.js';
+import { getBucket } from '../routes/bucket.js';
 
 function get404() {
   return { body: '', status: 404 };
@@ -29,6 +30,7 @@ export default async function getHandler({ env, daCtx }) {
   if (path.startsWith('/favicon.ico')) return get404();
   if (path.startsWith('/robots.txt')) return getRobots();
 
+  if (path.startsWith('/bucket')) return getBucket({ env, daCtx });
   if (path.startsWith('/source')) return getSource({ env, daCtx });
   if (path.startsWith('/list')) return getList({ env, daCtx });
   if (path.startsWith('/config')) return getConfig({ env, daCtx });

--- a/src/handlers/post.js
+++ b/src/handlers/post.js
@@ -14,10 +14,12 @@ import { postConfig } from '../routes/config.js';
 import { postVersionSource } from '../routes/version.js';
 import copyHandler from '../routes/copy.js';
 import renameHandler from '../routes/rename.js';
+import { postBucket } from '../routes/bucket.js';
 
 export default async function postHandler({ req, env, daCtx }) {
   const { path } = daCtx;
 
+  if (path.startsWith('/bucket')) return postBucket({ env, daCtx });
   if (path.startsWith('/source')) return postSource({ req, env, daCtx });
   if (path.startsWith('/config')) return postConfig({ req, env, daCtx });
   if (path.startsWith('/versionsource')) return postVersionSource({ env, daCtx });

--- a/src/routes/bucket.js
+++ b/src/routes/bucket.js
@@ -11,6 +11,8 @@
  */
 
 import get from '../storage/bucket/get.js';
+import { isAnonymous } from '../utils/auth.js';
+import put from '../storage/bucket/put.js';
 
 export async function getBucket({ env, daCtx }) {
   const bucket = await get(env, daCtx);
@@ -21,4 +23,13 @@ export async function getBucket({ env, daCtx }) {
     status,
     contentType: 'application/json',
   };
+}
+
+export async function postBucket({ env, daCtx }) {
+  if (isAnonymous(daCtx)) {
+    return { status: 401 };
+  }
+  const success = await put(env, daCtx);
+  const status = success ? 201 : 500;
+  return { status };
 }

--- a/src/routes/bucket.js
+++ b/src/routes/bucket.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import get from '../storage/bucket/get.js';
+
+export async function getBucket({ env, daCtx }) {
+  const bucket = await get(env, daCtx);
+  const status = bucket ? 200 : 404;
+  const body = bucket ? JSON.stringify(bucket) : undefined;
+  return {
+    body,
+    status,
+    contentType: 'application/json',
+  };
+}

--- a/src/storage/bucket/get.js
+++ b/src/storage/bucket/get.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import listBuckets from './list.js';
+
+/**
+ * Gets the bucket based on the current DaCtx
+ * @param env the Worker context
+ * @param daCtx the daCtx
+ * @return {Promise<Bucket>}
+ */
+export default async function getBucket(env, daCtx) {
+  // Don't need to check for auth - if we got this far, user has access to the bucket.
+  const resp = await listBuckets(env, daCtx);
+  const buckets = JSON.parse(resp.body);
+  return buckets.find((b) => b.name === daCtx.org);
+}

--- a/src/storage/bucket/put.js
+++ b/src/storage/bucket/put.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  S3Client,
+  CreateBucketCommand,
+} from '@aws-sdk/client-s3';
+import getS3Config from '../utils/config.js';
+
+/**
+ * Creates the bucket as specified by the org within the DaCtx
+ *
+ * @param env the worker environment
+ * @param daCtx the current context
+ * @return {Promise<boolean>} true if bucket was created, false if an error occurred
+ */
+export default async function putBuket(env, daCtx) {
+  const config = getS3Config(env);
+  const client = new S3Client(config);
+
+  const { org, users } = daCtx;
+  const input = {
+    Bucket: `${org}-content`,
+    ACL: 'private',
+  };
+
+  const command = new CreateBucketCommand(input);
+  try {
+    await client.send(command);
+
+    const data = [];
+    users.forEach((user) => {
+      data.push({ key: 'admin.role.all', value: user.email });
+    });
+
+    const sheet = {
+      total: data.length,
+      limit: data.length,
+      offset: 0,
+      data,
+      ':type': 'sheet',
+    };
+    await env.DA_CONFIG.put(org, JSON.stringify(sheet));
+
+    const orgs = await env.DA_AUTH.get('orgs', { type: 'json' });
+    orgs.push({ name: org, created: new Date().toISOString() });
+    await env.DA_AUTH.put('orgs', JSON.stringify(orgs));
+
+    return true;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log(e);
+    return false;
+  }
+}

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -77,3 +77,13 @@ export async function isAuthorized(env, org, user) {
   if (!admins) return true;
   return admins.some((admin) => admin === user.email);
 }
+
+/**
+ * Checks if any of the users within this context are anonymous
+ * @param daCtx the current context
+ * @return {boolean} true if any users are anonymous, false otherwise
+ */
+export function isAnonymous(daCtx) {
+  const { users } = daCtx;
+  return users.some((user) => user.email === 'anonymous');
+}

--- a/test/routes/bucket.test.js
+++ b/test/routes/bucket.test.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { strict as assert } from 'node:assert';
+import esmock from 'esmock';
+
+describe('bucket route', () => {
+  it('handles found bucket', async () => {
+    const bucket = { name: 'Found', created: new Date() };
+    const { getBucket } = await esmock(
+      '../../src/routes/bucket.js',
+      {
+        '../../src/storage/bucket/get.js': {
+          default: async () => bucket
+        },
+      }
+    );
+    const resp = await getBucket({ env: {}, daCtx: {} })
+    assert.strictEqual(resp.body, JSON.stringify(bucket), 'Body correct');
+    assert.equal(resp.status, 200, 'Status correct.');
+  });
+
+  it('handles not found bucket', async () => {
+    const { getBucket } = await esmock(
+      '../../src/routes/bucket.js',
+      {
+        '../../src/storage/bucket/get.js': {
+          default: async () => undefined
+        },
+      }
+    );
+    const resp = await getBucket({ env: {}, daCtx: {} })
+    assert.ifError(resp.body);
+    assert.equal(resp.status, 404, 'Status correct.');
+  });
+});

--- a/test/storage/bucket/get.test.js
+++ b/test/storage/bucket/get.test.js
@@ -11,41 +11,35 @@
  */
 
 import { strict as assert } from 'node:assert';
-import esmock from 'esmock';
+import { strict as esmock } from 'esmock';
+
+import env from '../../utils/mocks/env.js';
+
+const buckets = [
+  { name: 'test-org', created: new Date() },
+  { name: 'another-org', created: new Date() },
+  { name: 'yet-another-org', created: new Date() },
+]
+const resp = {
+  body: JSON.stringify(buckets),
+  status: 200,
+  contentType: 'application/json',
+}
+
+const getBucket = await esmock(
+  '../../../src/storage/bucket/get.js', {
+    '../../../src/storage/bucket/list.js': { default: async () => resp },
+  }
+);
 
 describe('get buckets', () => {
-  const buckets = [
-    { name: 'test-org', created: new Date() },
-    { name: 'another-org', created: new Date() },
-    { name: 'yet-another-org', created: new Date() },
-  ]
-  const resp = {
-    body: JSON.stringify(buckets),
-    status: 200,
-    contentType: 'application/json',
-  }
-
   it('returns found bucket', async() => {
-    const getBucket = await esmock(
-      '../../../src/storage/bucket/get.js',
-      {
-        '../../../src/storage/bucket/list.js': { default: async () => resp },
-      }
-    );
-
-    const result = await getBucket({}, { org: 'test-org'});
+    const result = await getBucket(env, { org: 'test-org'});
     assert.deepStrictEqual(result.name, 'test-org', 'Found bucket.');
   });
 
   it('returns not found bucket', async() => {
-    const getBucket = await esmock(
-      '../../../src/storage/bucket/get.js',
-      {
-        '../../../src/storage/bucket/list.js': { default: async () => resp },
-      }
-    );
-
-    const result = await getBucket({}, { org: 'does-not-exist'});
+    const result = await getBucket(env, { org: 'does-not-exist'});
     assert.ifError(result);
   })
 });

--- a/test/storage/bucket/get.test.js
+++ b/test/storage/bucket/get.test.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { strict as assert } from 'node:assert';
+import esmock from 'esmock';
+
+describe('get buckets', () => {
+  const buckets = [
+    { name: 'test-org', created: new Date() },
+    { name: 'another-org', created: new Date() },
+    { name: 'yet-another-org', created: new Date() },
+  ]
+  const resp = {
+    body: JSON.stringify(buckets),
+    status: 200,
+    contentType: 'application/json',
+  }
+
+  it('returns found bucket', async() => {
+    const getBucket = await esmock(
+      '../../../src/storage/bucket/get.js',
+      {
+        '../../../src/storage/bucket/list.js': { default: async () => resp },
+      }
+    );
+
+    const result = await getBucket({}, { org: 'test-org'});
+    assert.deepStrictEqual(result.name, 'test-org', 'Found bucket.');
+  });
+
+  it('returns not found bucket', async() => {
+    const getBucket = await esmock(
+      '../../../src/storage/bucket/get.js',
+      {
+        '../../../src/storage/bucket/list.js': { default: async () => resp },
+      }
+    );
+
+    const result = await getBucket({}, { org: 'does-not-exist'});
+    assert.ifError(result);
+  })
+});

--- a/test/storage/bucket/put.test.js
+++ b/test/storage/bucket/put.test.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { strict as assert } from 'node:assert';
+import env from '../../utils/mocks/env.js';
+
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  S3Client,
+  CreateBucketCommand,
+  BucketAlreadyExists
+} from '@aws-sdk/client-s3';
+
+import putBucket from '../../../src/storage/bucket/put.js';
+
+
+describe('Bucket creation', () => {
+  let s3Mock;
+  beforeEach(() => {
+    s3Mock = mockClient(S3Client);
+  })
+
+  it('creates a bucket', async () => {
+    const org = 'new-bucket';
+    const email = 'test@example.com';
+    const daCtx = {
+      org,
+      users: [{ email }]
+    };
+    s3Mock
+      .on(CreateBucketCommand)
+      .callsFake((input) => {
+        return { Location: `/${input.Bucket}` }
+      });
+    const result = await putBucket(env, daCtx);
+    // Bucket was created
+    assert.strictEqual(result, true, 'Correct response.');
+    const calls = s3Mock.commandCalls(CreateBucketCommand, { Bucket: 'new-bucket-content', ACL: 'private' });
+    assert.deepStrictEqual(calls.length, 1, 'S3 Called.');
+
+    // Permissions set on Bucket
+    const config = env.DA_CONFIG.get(org, { type: 'json' });
+    const foundRole = config.data.find((c) => {
+      return c.key === 'admin.role.all' && c.value === email;
+    });
+    assert(foundRole, 'Role set');
+
+    // Org list updated
+    const orgs = env.DA_AUTH.get('orgs', { type: 'json' });
+    const foundOrg = orgs.find((o) => o.name === org);
+    assert(foundOrg, 'Org list updated.');
+  });
+
+
+  it('gracefully handles errors', async () => {
+    s3Mock
+      .on(CreateBucketCommand)
+      .callsFake(() => {
+        throw new BucketAlreadyExists();
+      });
+    const result = await putBucket(env, { org: 'existing' });
+    assert.strictEqual(result, false, 'Correct response.');
+    const calls = s3Mock.commandCalls(CreateBucketCommand, { Bucket: 'existing-content', ACL: 'private' });
+    assert.deepStrictEqual(calls.length, 1, 'S3 Called.');
+  })
+});

--- a/test/storage/object/put.test.js
+++ b/test/storage/object/put.test.js
@@ -6,7 +6,6 @@ import env from '../../utils/mocks/env.js';
 import { mockClient } from 'aws-sdk-client-mock';
 import { S3Client } from '@aws-sdk/client-s3';
 
-const s3Mock = mockClient(S3Client);
 
 import { putObjectWithVersion, postObjectVersion } from './mocks/version/put.js';
 const putObject = await esmock('../../../src/storage/object/put.js', {
@@ -17,8 +16,10 @@ const putObject = await esmock('../../../src/storage/object/put.js', {
 });
 
 describe('Object storage', () => {
+  let s3Mock;
+
   beforeEach(() => {
-    s3Mock.reset();
+    s3Mock = mockClient(S3Client);
   });
 
   describe('Put success', async () => {

--- a/test/utils/mocks/env.js
+++ b/test/utils/mocks/env.js
@@ -7,7 +7,7 @@ const NAMESPACES = {
   ]
 };
 const DA_CONFIG = {
-  'geometrixx': {
+  'geometrixx': JSON.stringify({
     "total": 1,
     "limit": 1,
     "offset": 0,
@@ -18,7 +18,7 @@ const DA_CONFIG = {
         }
     ],
     ":type": "sheet"
-  }
+  }),
 };
 
 const env = {
@@ -32,10 +32,19 @@ const env = {
     put: (kvNamespace, value, expObj) => {},
   },
   DA_CONFIG: {
-    get: (name) => {
-      return DA_CONFIG[name];
+    get: (name, opt) => {
+      const value = DA_CONFIG[name];
+      if (!value) {
+        return null;
+      }
+      if (opt.type === 'json') {
+          return JSON.parse(value);
+      }
+      return value;
     },
-    put: (name, value, expObj) => {},
+    put: (name, value, expObj) => {
+      DA_CONFIG[name] = value;
+    },
   }
 };
 


### PR DESCRIPTION
## Description

Add checks for access to creating buckets, and when creating a new bucket set the access to the authenticated user.

## Related Issue

Impl #41 

## Motivation and Context

So all new buckets are secure going forward.

## How Has This Been Tested?

Added unit tests. Also ran some quick Postman checks locally.

## Screenshots (if appropriate):

## Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
