### PR TITLE
 Always create a new version when a version store is requested

### DIFF
--- a/src/routes/source.js
+++ b/src/routes/source.js
@@ -18,20 +18,10 @@ import { postObjectVersion } from '../storage/version/put.js';
 
 async function invalidateCollab(api, url, env) {
   const invPath = `/api/v1/${api}?doc=${url}`;
-  if (env.dacollab) {
-    // service binding is configured, hostname is not relevant
-    console.log('Using service binding');
-    const invURL = `https://localhost${invPath}`;
-    await env.dacollab.fetch(invURL);
-  } else if (env.DA_COLLAB) {
-    // use internet host-port as configured via DA_COLLAB env var
-    console.log('Using service DA_COLLAB env var');
-    const invURL = `${env.DA_COLLAB}${invPath}`;
-    await fetch(invURL);
-  } else {
-    // eslint-disable-next-line no-console
-    console.log('Not invalidating collab, neither dacollab service binding nor DA_COLLAB env var set');
-  }
+
+  // Use dacollab service binding, hostname is not relevant
+  const invURL = `https://localhost${invPath}`;
+  await env.dacollab.fetch(invURL);
 }
 
 export async function deleteSource({ req, env, daCtx }) {

--- a/src/storage/object/put.js
+++ b/src/storage/object/put.js
@@ -89,7 +89,7 @@ export default async function putObject(env, daCtx, obj) {
       const { body, type } = isFile ? await getFileBody(obj.data) : getObjectBody(obj.data);
       status = await putObjectWithVersion(env, daCtx, {
         org, key, body, type,
-      }, true);
+      });
     }
   } else {
     const { body, type } = getObjectBody({});

--- a/src/storage/version/put.js
+++ b/src/storage/version/put.js
@@ -45,49 +45,12 @@ function buildInput({
   };
 }
 
-export async function postObjectVersion(req, env, daCtx) {
-  let reqJSON;
-  try {
-    reqJSON = await req.json();
-  } catch (e) {
-    // no label
-  }
-
-  const config = getS3Config(env);
-  const update = buildInput(daCtx);
-  const current = await getObject(env, daCtx);
-  if (current.status === 404 || !current.metadata?.id || !current.metadata?.version) {
-    return 404;
-  }
-
-  let existingVersion;
-  if (reqJSON?.label === undefined) {
-    existingVersion = await getObject(env, {
-      org: daCtx.org,
-      key: `.da-versions/${current.metadata.id}/${current.metadata.version}.${daCtx.ext}`,
-    });
-  }
-  const label = reqJSON?.label || existingVersion?.metadata?.label;
-
-  const resp = await putVersion(config, {
-    Bucket: update.Bucket,
-    Body: current.body,
-    ID: current.metadata.id,
-    Version: current.metadata.version,
-    Ext: daCtx.ext,
-    Metadata: {
-      Users: current.metadata?.users || JSON.stringify([{ email: 'anonymous' }]),
-      Timestamp: current.metadata?.timestamp || `${Date.now()}`,
-      Path: current.metadata?.path || daCtx.key,
-      Label: label,
-    },
-  }, false);
-  return { status: resp.status === 200 ? 201 : resp.status };
-}
-
 export async function putObjectWithVersion(env, daCtx, update, body) {
   const config = getS3Config(env);
-  const current = await getObject(env, update, !body);
+  // While we are automatically storing the body once for the 'Collab Parse' changes, we never
+  // do a HEAD, because we may need the content. Once we don't need to do this automatic store
+  // any more, we can change the 'false' argument in the next line back to !body.
+  const current = await getObject(env, update, false);
 
   const ID = current.metadata?.id || crypto.randomUUID();
   const Version = current.metadata?.version || crypto.randomUUID();
@@ -118,13 +81,13 @@ export async function putObjectWithVersion(env, daCtx, update, body) {
   const pps = current.metadata?.preparsingstore || '0';
 
   // Store the body if preparsingstore is not defined, so a once-off store
-  const storeBody = body && pps === '0';
+  const storeBody = !body && pps === '0';
   const Preparsingstore = storeBody ? Timestamp : pps;
-  const Label = storeBody ? 'Collab Parse' : undefined;
+  const Label = storeBody ? 'Collab Parse' : update.label;
 
   const versionResp = await putVersion(config, {
     Bucket: input.Bucket,
-    Body: (storeBody ? current.body : ''),
+    Body: (body || storeBody ? current.body : ''),
     ID,
     Version,
     Ext: daCtx.ext,
@@ -157,4 +120,23 @@ export async function putObjectWithVersion(env, daCtx, update, body) {
     }
     return e.$metadata.httpStatusCode;
   }
+}
+
+export async function postObjectVersion(req, env, daCtx) {
+  let reqJSON;
+  try {
+    reqJSON = await req.json();
+  } catch (e) {
+    // no body
+  }
+  const label = reqJSON?.label;
+
+  const { body, contentType } = await getObject(env, daCtx);
+  const { org, key } = daCtx;
+
+  const resp = await putObjectWithVersion(env, daCtx, {
+    org, key, body, contentType, label,
+  }, true);
+
+  return { status: resp === 200 ? 201 : resp };
 }

--- a/src/storage/version/put.js
+++ b/src/storage/version/put.js
@@ -135,7 +135,7 @@ export async function postObjectVersion(req, env, daCtx) {
   const { org, key } = daCtx;
 
   const resp = await putObjectWithVersion(env, daCtx, {
-    org, key, body, contentType, label,
+    org, key, body, type: contentType, label,
   }, true);
 
   return { status: resp === 200 ? 201 : resp };

--- a/test/storage/version/put.test.js
+++ b/test/storage/version/put.test.js
@@ -13,179 +13,6 @@ import assert from 'assert';
 import esmock from 'esmock';
 
 describe('Version Put', () => {
-  it('Post Object Version', async () => {
-    const mockGetObject = async () => {
-      const metadata = {
-        id: 'id',
-        version: '123'
-      }
-      return { metadata };
-    };
-
-    const sentToS3 = [];
-    const s3Client = {
-      send: async (c) => {
-        sentToS3.push(c);
-        return {
-          $metadata: {
-            httpStatusCode: 200
-          }
-        };
-      }
-    };
-    const mockS3Client = () => s3Client;
-
-    const { postObjectVersion } = await esmock('../../../src/storage/version/put.js', {
-      '../../../src/storage/object/get.js': {
-        default: mockGetObject
-      },
-      '../../../src/storage/utils/version.js': {
-        createBucketIfMissing: mockS3Client
-      },
-    });
-
-    const dn = { label: 'my label' };
-    const req = {
-      json: async () => dn
-    };
-    const env = {};
-    const daCtx = {
-      org: 'myorg',
-      key: '/a/b/c',
-      ext: 'html'
-    };
-
-    const resp = await postObjectVersion(req, env, daCtx);
-    assert.equal(201, resp.status);
-
-    assert.equal(1, sentToS3.length);
-    const input = sentToS3[0].input;
-    assert.equal('myorg-content', input.Bucket);
-    assert.equal('.da-versions/id/123.html', input.Key);
-    assert.equal('[{"email":"anonymous"}]', input.Metadata.Users);
-    assert.equal('my label', input.Metadata.Label);
-    assert(input.Metadata.Timestamp > (Date.now() - 2000)); // Less than 2 seconds old
-    assert.equal('/a/b/c', input.Metadata.Path);
-  });
-
-  it('Post Object Version 2', async () => {
-    const mockGetObject = async () => {
-      const metadata = {
-        label: 'old label',
-        id: 'idx',
-        version: '456',
-        path: '/y/z',
-        timestamp: 999,
-        users: '[{"email":"foo@acme.org"}]',
-      }
-      return { metadata };
-    };
-
-    const sentToS3 = [];
-    const s3Client = {
-      send: async (c) => {
-        sentToS3.push(c);
-        return {
-          $metadata: {
-            httpStatusCode: 202
-          }
-        };
-      }
-    };
-    const mockS3Client = () => s3Client;
-
-    const { postObjectVersion } = await esmock('../../../src/storage/version/put.js', {
-      '../../../src/storage/object/get.js': {
-        default: mockGetObject
-      },
-      '../../../src/storage/utils/version.js': {
-        createBucketIfMissing: mockS3Client
-      },
-    });
-
-    const dn = { label: 'my label' };
-    const req = {};
-    const env = {};
-    const daCtx = {
-      org: 'someorg',
-      key: '/a/b/c',
-      ext: 'html'
-    };
-
-    const resp = await postObjectVersion(req, env, daCtx);
-    assert.equal(202, resp.status);
-
-    assert.equal(1, sentToS3.length);
-    const input = sentToS3[0].input;
-    assert.equal('someorg-content', input.Bucket);
-    assert.equal('.da-versions/idx/456.html', input.Key);
-    assert.equal('[{"email":"foo@acme.org"}]', input.Metadata.Users);
-    assert.equal('old label', input.Metadata.Label);
-    assert.equal(999, input.Metadata.Timestamp);
-    assert.equal('/y/z', input.Metadata.Path);
-  });
-
-  it('Post Object Version where Label already exists', async () => {
-    const mockGetObject = async (e, x) => {
-      if (x.key === '.da-versions/idx/456.myext') {
-        const mdver = {
-          label: 'existing label',
-        };
-        return { metadata: mdver };
-      }
-      const metadata = {
-        id: 'idx',
-        version: '456',
-        path: '/y/z',
-        timestamp: 999,
-        users: '[{"email":"one@acme.org"},{"email":"two@acme.org"}]',
-      }
-      return { metadata };
-    };
-
-    const sentToS3 = [];
-    const s3Client = {
-      send: async (c) => {
-        sentToS3.push(c);
-        return {
-          $metadata: {
-            httpStatusCode: 200
-          }
-        };
-      }
-    };
-    const mockS3Client = () => s3Client;
-
-    const { postObjectVersion } = await esmock('../../../src/storage/version/put.js', {
-      '../../../src/storage/object/get.js': {
-        default: mockGetObject
-      },
-      '../../../src/storage/utils/version.js': {
-        createBucketIfMissing: mockS3Client
-      },
-    });
-
-    const dn = { label: 'my label' };
-    const req = {};
-    const env = {};
-    const daCtx = {
-      org: 'someorg',
-      key: '/a/b/c',
-      ext: 'myext'
-    };
-
-    const resp = await postObjectVersion(req, env, daCtx);
-    assert.equal(201, resp.status);
-
-    assert.equal(1, sentToS3.length);
-    const input = sentToS3[0].input;
-    assert.equal('someorg-content', input.Bucket);
-    assert.equal('.da-versions/idx/456.myext', input.Key);
-    assert.equal('[{"email":"one@acme.org"},{"email":"two@acme.org"}]', input.Metadata.Users);
-    assert.equal('existing label', input.Metadata.Label);
-    assert.equal('/y/z', input.Metadata.Path);
-  });
-
   it('Test putObjectWithVersion retry on new document', async () => {
     const getObjectCalls = []
     const mockGetObject = async (e, u, nb) => {
@@ -233,10 +60,10 @@ describe('Version Put', () => {
     assert.equal(2, getObjectCalls.length);
     assert.equal(getObjectCalls[0].e, mockEnv);
     assert.equal(getObjectCalls[0].u, mockUpdate);
-    assert.equal(getObjectCalls[0].nb, true);
+    assert.equal(getObjectCalls[0].nb, false);
     assert.equal(getObjectCalls[1].e, mockEnv);
     assert.equal(getObjectCalls[1].u, mockUpdate);
-    assert.equal(getObjectCalls[1].nb, true);
+    assert.equal(getObjectCalls[1].nb, false);
 
     assert.equal(2, sendCalls.length);
     assert.strictEqual(sendCalls[0].input.Metadata.Users, JSON.stringify(mockCtx.users));
@@ -373,7 +200,6 @@ describe('Version Put', () => {
     assert.equal('/a/x.html', s3Sent[0].input.Metadata.Path);
     assert.notEqual('aaa-bbb', s3Sent[0].input.Metadata.Version);
     assert(s3Sent[0].input.Metadata.Timestamp > 0);
-    assert.equal(s3Sent[0].input.Metadata.Preparsingstore, s3Sent[0].input.Metadata.Timestamp);
   });
 
   it('Put Object With Version don\'t store content', async () => {
@@ -422,7 +248,7 @@ describe('Version Put', () => {
     const env = {};
     const daCtx= { ext: 'html', users: [{"email": "foo@acme.org"}, {"email": "bar@acme.org"}] };
     const update = { body: 'new-body', org: 'myorg', key: '/a/x.html' };
-    const resp = await putObjectWithVersion(env, daCtx, update, true);
+    const resp = await putObjectWithVersion(env, daCtx, update, false);
     assert.equal(202, resp);
     assert.equal(1, s3VersionSent.length);
     assert.equal('', s3VersionSent[0].input.Body);
@@ -487,5 +313,84 @@ describe('Version Put', () => {
     assert.equal('/a/b/c', s3Sent[0].input.Metadata.Path);
     assert(s3Sent[0].input.Metadata.Timestamp > 0);
     assert(s3Sent[0].input.Metadata.Version);
+  });
+
+  it('Post Object With Version creates new version', async () => {
+    const req = {
+      json: () => ({
+        label: 'foobar'
+      })
+    };
+    const env = {};
+    const ctx = {
+      org: 'org123',
+      key: '/q/r/t'
+    };
+
+    const mockGetObject = async (e, u, h) => {
+      if (e === env && !h) {
+        return {
+          body: 'doccontent',
+          contentType: 'text/html',
+        };
+      }
+    }
+
+
+    const s3Sent = [];
+    const mockS3Client = {
+      send: (c) => {
+        s3Sent.push(c);
+        return {
+          $metadata: {
+            httpStatusCode: 200
+          }
+        };
+      }
+    };
+    const mockIfMatch = () => mockS3Client;
+
+    const s3INMSent = [];
+    const mockS3INMClient = {
+      send: (c) => {
+        s3INMSent.push(c);
+        return {
+          $metadata: {
+            httpStatusCode: 200
+          }
+        };
+      }
+    };
+    const mockIfNoneMatch = () => mockS3INMClient;
+
+    const { postObjectVersion } = await esmock('../../../src/storage/version/put.js', {
+      '../../../src/storage/object/get.js': {
+        default: mockGetObject
+      },
+      '../../../src/storage/utils/version.js': {
+        ifMatch: mockIfMatch,
+        ifNoneMatch: mockIfNoneMatch
+      },
+    });
+
+    const resp = await postObjectVersion(req, env, ctx);
+    assert.equal(201, resp.status);
+    assert.equal(1, s3INMSent.length);
+    assert.equal('doccontent', s3INMSent[0].input.Body);
+    assert.equal('org123-content', s3INMSent[0].input.Bucket);
+    assert.equal('/q/r/t', s3INMSent[0].input.Metadata.Path);
+    assert(s3INMSent[0].input.Metadata.Timestamp > 0);
+    assert.equal('[{"email":"anonymous"}]', s3INMSent[0].input.Metadata.Users);
+    assert.equal('foobar', s3INMSent[0].input.Metadata.Label);
+
+    assert.equal(1, s3Sent.length);
+    assert.equal('doccontent', s3Sent[0].input.Body);
+    assert.equal('org123-content', s3Sent[0].input.Bucket);
+    assert.equal('/q/r/t', s3Sent[0].input.Key);
+    assert.equal('/q/r/t', s3Sent[0].input.Metadata.Path);
+    assert(s3Sent[0].input.Metadata.ID);
+    assert(s3Sent[0].input.Metadata.Timestamp > 0);
+    assert(s3Sent[0].input.Metadata.Version);
+    assert.equal('text/html', s3Sent[0].input.ContentType);
   });
 });


### PR DESCRIPTION
## Description

Whenever a stored version is requested by the user, a new stored version is created, regardless of whether there already was a stored version with the same content.

Also cleaned up the da-admin -> da-collab communication to always use a service binding.

Fixes: #46 

## How Has This Been Tested?

* Locally with da-live and da-collab
* Unit tests

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
