### PR TITLE
Add new metadata for pure copies to get them a new version history

### DIFF
--- a/src/routes/copy.js
+++ b/src/routes/copy.js
@@ -14,5 +14,5 @@ import copyHelper from '../helpers/copy.js';
 
 export default async function copyHandler({ req, env, daCtx }) {
   const details = await copyHelper(req, daCtx);
-  return copyObject(env, daCtx, details);
+  return copyObject(env, daCtx, details, false);
 }

--- a/src/storage/object/rename.js
+++ b/src/storage/object/rename.js
@@ -14,7 +14,7 @@ import deleteObjects from './delete.js';
 
 const rename = async (env, daCtx, details) => {
   try {
-    await copyObject(env, daCtx, details);
+    await copyObject(env, daCtx, details, true);
     await deleteObjects(env, daCtx);
   } catch (e) {
     // eslint-disable-next-line no-console

--- a/test/storage/object/copy.test.js
+++ b/test/storage/object/copy.test.js
@@ -1,0 +1,67 @@
+import assert from 'assert';
+import esmock from 'esmock';
+import { copyFile } from '../../../src/storage/object/copy.js';
+
+import { mockClient } from 'aws-sdk-client-mock';
+import { S3Client } from '@aws-sdk/client-s3';
+
+const s3Mock = mockClient(S3Client);
+
+describe('Object copy', () => {
+  it('Copies a file', async () => {
+    const s3Sent = [];
+    const mockS3Client = {
+      send(command) {
+        s3Sent.push(command);
+      }
+    };
+
+    const ctx = {
+      org: 'foo',
+      users: [{email: "haha@foo.com"}],
+    };
+    const sourceKey = 'mydir/xyz.html';
+    const details = {
+      source: 'mydir',
+      destination: 'mydir/newdir',
+    };
+    copyFile(mockS3Client, ctx, sourceKey, details, false);
+
+    assert.equal(1, s3Sent.length);
+    const input = s3Sent[0].input;
+    assert.equal('foo-content', input.Bucket);
+    assert.equal('foo-content/mydir/xyz.html', input.CopySource);
+    assert.equal('mydir/newdir/xyz.html', input.Key);
+
+    const md = input.Metadata;
+    assert(md.ID, "ID should be set");
+    assert(md.Version, "Version should be set");
+    assert.equal('string', typeof(md.Timestamp), "Timestamp should be set as a string");
+    assert.equal(md.Users, '[{"email":"haha@foo.com"}]');
+    assert.equal(md.Path, 'mydir/newdir');
+  });
+
+  it('Copies a file for rename', async () => {
+    const s3Sent = [];
+    const mockS3Client = {
+      send(command) {
+        s3Sent.push(command);
+      }
+    };
+
+    const ctx = { org: 'testorg' };
+    const sourceKey = 'mydir/dir1/myfile.html';
+    const details = {
+      source: 'mydir/dir1',
+      destination: 'mydir/dir2',
+    };
+    copyFile(mockS3Client, ctx, sourceKey, details, true);
+
+    assert.equal(1, s3Sent.length);
+    const input = s3Sent[0].input;
+    assert.equal('testorg-content', input.Bucket);
+    assert.equal('testorg-content/mydir/dir1/myfile.html', input.CopySource);
+    assert.equal('mydir/dir2/myfile.html', input.Key);
+    assert(input.Metadata === undefined, "Should not redefine metadata for rename");
+  });
+});


### PR DESCRIPTION
## Description

When a resource is copied it should get a fresh version history.

The rename operation also uses the copy operation internally, in that case existing metadata is reused as before to preserve version history.

## Related Issue

Fixes #56

## How Has This Been Tested?

* Tested locally with da-live and da-collab
* Unit tests for the changed code
* Playwright tests will be added soon too


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
