### PR TITLE
Include coverage for all source files

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -5,8 +5,9 @@
     "text-summary"
   ],
   "check-coverage": true,
-  "lines": 60,
+  "lines": 45,
   "branches": 80,
-  "statements": 60,
+  "statements": 45,
+  "functions": 50,
   "skip-full": true
 }

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -5,6 +5,8 @@
     "text-summary"
   ],
   "check-coverage": true,
+  "all": true,
+  "include": ["src/**/*.js"],
   "lines": 45,
   "branches": 80,
   "statements": 45,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "docs:build": "npx @redocly/cli build-docs -o docs/index.html admin@v1",
     "docs:watch": "npx @redocly/cli preview-docs admin@v1",
     "lint": "eslint .",
-    "test": "c8 mocha --spec=test/**/*.test.js",
+    "test": "c8 --all --src src mocha --spec=test/**/*.test.js",
     "dev": "wrangler dev",
     "deploy:prod": "wrangler deploy",
     "deploy:stage": "wrangler deploy --env stage",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "docs:build": "npx @redocly/cli build-docs -o docs/index.html admin@v1",
     "docs:watch": "npx @redocly/cli preview-docs admin@v1",
     "lint": "eslint .",
-    "test": "c8 --all --src src mocha --spec=test/**/*.test.js",
+    "test": "c8 mocha --spec=test/**/*.test.js",
     "dev": "wrangler dev",
     "deploy:prod": "wrangler deploy",
     "deploy:stage": "wrangler deploy --env stage",


### PR DESCRIPTION
## Description

Previously coverage figures were only on source files touched by unit tests, which meant that if you added tests to a previously untested sourcefile, it would typically bring the overall coverage down, unless that new file was immediately close to 100% covered. 

This change computes coverage figures on **_all_** source files, which is more truthful. 

It will seriously bring the coverage figure down, but the new coverage figure is the correct one.

Also updated `.nycrc.json` to accept the current figure as the minimum one.

## Types of changes

A build system fix. No change to the actual product code.

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
