### PR TITLE
GH-68 - Move API

### DIFF
--- a/src/handlers/post.js
+++ b/src/handlers/post.js
@@ -14,6 +14,7 @@ import { postConfig } from '../routes/config.js';
 import { postVersionSource } from '../routes/version.js';
 import copyHandler from '../routes/copy.js';
 import renameHandler from '../routes/rename.js';
+import moveRoute from '../routes/move.js';
 
 export default async function postHandler({ req, env, daCtx }) {
   const { path } = daCtx;
@@ -23,6 +24,7 @@ export default async function postHandler({ req, env, daCtx }) {
   if (path.startsWith('/versionsource')) return postVersionSource({ req, env, daCtx });
   if (path.startsWith('/copy')) return copyHandler({ req, env, daCtx });
   if (path.startsWith('/rename')) return renameHandler({ req, env, daCtx });
+  if (path.startsWith('/move')) return moveRoute({ req, env, daCtx });
 
   return undefined;
 }

--- a/src/helpers/move.js
+++ b/src/helpers/move.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const NO_DEST_ERROR = {
+  body: JSON.stringify({ error: 'No destination provided.' }),
+  status: 400,
+};
+
+const NO_PARENT_ERROR = {
+  body: JSON.stringify({ error: 'Destination cannot be descendent of source.' }),
+  status: 400,
+};
+
+export default async function moveHelper(req, daCtx) {
+  try {
+    const formData = await req.formData();
+    if (!formData) return {};
+    const fullDest = formData.get('destination');
+    if (!fullDest) return { error: NO_DEST_ERROR };
+    const lower = fullDest.slice(1).toLowerCase();
+    const sanitized = lower.endsWith('/') ? lower.slice(0, -1) : lower;
+    let destination = sanitized.split('/').slice(1).join('/');
+    const source = daCtx.key;
+
+    // Ensure destination is not child of source
+    if (destination.startsWith(`${source}/`)) {
+      return { error: NO_PARENT_ERROR };
+    }
+
+    // Timestamp if the names are the same
+    if (destination === source) {
+      destination = `${source}-${Date.now()}`;
+    }
+
+    return { source, destination };
+  } catch {
+    return { error: NO_DEST_ERROR };
+  }
+}

--- a/src/routes/move.js
+++ b/src/routes/move.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import moveObject from '../storage/object/move.js';
+import moveHelper from '../helpers/move.js';
+
+export default async function moveRoute({ req, env, daCtx }) {
+  const details = await moveHelper(req, daCtx);
+  if (details.error) return details.error;
+  return moveObject(env, daCtx, details);
+}


### PR DESCRIPTION
* Rename / Move is faster (more concurrent)
* Server-side API handles trying to rename / move a parent into a child.
* Server-side API handles trying to rename / move to the same location as the original source (add a timestamp)
* Rename / move is more reliable. If a file is moved, it should never exist anywhere else.
* Can reliably handle 10,000 documents in ~20s.

Resolves: GH-68

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
