### PR TITLE
 GH-79 Copy and delete performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "watch:docs": "npx @redocly/cli preview-docs admin@v1",
     "lint": "eslint .",
     "test": "c8 mocha --spec=test/**/*.test.js",
+    "test:it": "mocha --spec=test/it/**/*.spec.js",
     "dev": "wrangler dev",
     "deploy:prod": "wrangler deploy",
     "deploy:stage": "wrangler deploy --env stage",

--- a/src/helpers/copy.js
+++ b/src/helpers/copy.js
@@ -13,9 +13,13 @@ export default async function copyHelper(req, daCtx) {
   const formData = await req.formData();
   if (!formData) return {};
   const fullDest = formData.get('destination');
+  let remaining = formData.get('remaining');
+  if (remaining) {
+    remaining = JSON.parse(remaining);
+  }
   const lower = fullDest.slice(1).toLowerCase();
   const sanitized = lower.endsWith('/') ? lower.slice(0, -1) : lower;
   const destination = sanitized.split('/').slice(1).join('/');
   const source = daCtx.key;
-  return { source, destination };
+  return { source, destination, remaining };
 }

--- a/src/storage/object/copy.js
+++ b/src/storage/object/copy.js
@@ -65,18 +65,19 @@ export default async function copyObject(env, daCtx, details, isRename) {
   const config = getS3Config(env);
   const client = new S3Client(config);
 
-  const sourceKeys = [];
-  const remaining = [];
+  let sourceKeys;
+  let remaining;
 
   if (details.remaining) {
-    sourceKeys.push(...details.remaining.splice(0, MaxKeys));
-    remaining.push(...details.remaining);
+    sourceKeys = details.remaining.splice(0, MaxKeys);
+    remaining = details.remaining;
   } else {
     const input = buildInput(daCtx.org, details.source);
 
     // The input prefix has a forward slash to prevent (drafts + drafts-new, etc.).
     // Which means the list will only pickup children. This adds to the initial list.
-    sourceKeys.push(details.source, `${details.source}.props`);
+    sourceKeys = [details.source, `${details.source}.props`];
+    remaining = [];
     let ContinuationToken;
 
     try {

--- a/src/storage/object/delete.js
+++ b/src/storage/object/delete.js
@@ -14,7 +14,6 @@ import {
   DeleteObjectCommand,
   ListObjectsV2Command,
 } from '@aws-sdk/client-s3';
-import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
 import getS3Config from '../utils/config.js';
 import { postObjectVersionWithLabel } from '../version/put.js';
@@ -44,8 +43,7 @@ export async function deleteObject(client, daCtx, Key, env, isMove = false) {
   let resp;
   try {
     const delCommand = new DeleteObjectCommand({ Bucket: `${daCtx.org}-content`, Key });
-    const url = await getSignedUrl(client, delCommand, { expiresIn: 3600 });
-    resp = await fetch(url, { method: 'DELETE' });
+    resp = await client.send(delCommand);
   } catch (e) {
     // eslint-disable-next-line no-console
     console.log(`There was an error deleting ${Key}.`);
@@ -56,43 +54,49 @@ export async function deleteObject(client, daCtx, Key, env, isMove = false) {
     await invalidateCollab('deleteadmin', `${daCtx.origin}/source/${daCtx.org}/${Key}`, env);
   }
 
-  return resp;
+  return { status: resp.$metadata.httpStatusCode, body: '' };
 }
 
+/**
+ * Deletes the first subset of the list provided.
+ * If the list is exhausted, it will return 204, otherwise 206 to indicate more work.
+ *
+ * @param env the CloudFlare environment
+ * @param daCtx the DA Context
+ * @return {Promise<{body: null, status: (number)}|{body: string, status: number}>}
+ */
 export default async function deleteObjects(env, daCtx) {
   const config = getS3Config(env);
   const client = new S3Client(config);
   const input = buildInput(daCtx.org, daCtx.key);
 
-  let ContinuationToken;
-
   // The input prefix has a forward slash to prevent (drafts + drafts-new, etc.).
   // Which means the list will only pickup children. This adds to the initial list.
   const sourceKeys = [daCtx.key, `${daCtx.key}.props`];
 
-  do {
-    try {
-      const command = new ListObjectsV2Command({ ...input, ContinuationToken });
-      const resp = await client.send(command);
+  let ContinuationToken;
 
-      const { Contents = [], NextContinuationToken } = resp;
-      sourceKeys.push(...Contents.map(({ Key }) => Key));
+  try {
+    const command = new ListObjectsV2Command({ ...input });
+    const resp = await client.send(command);
 
-      await Promise.all(
-        new Array(1).fill(null).map(async () => {
-          while (sourceKeys.length) {
-            await deleteObject(client, daCtx, sourceKeys.pop(), env);
-          }
-        }),
-      );
+    const { Contents = [], NextContinuationToken } = resp;
+    sourceKeys.push(...Contents.map(({ Key }) => Key));
 
-      ContinuationToken = NextContinuationToken;
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.log(e);
-      return { body: '', status: 404 };
-    }
-  } while (ContinuationToken);
+    await Promise.all(
+      new Array(1).fill(null).map(async () => {
+        while (sourceKeys.length) {
+          await deleteObject(client, daCtx, sourceKeys.pop(), env);
+        }
+      }),
+    );
 
-  return { body: null, status: 204 };
+    ContinuationToken = NextContinuationToken;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log(e);
+    return { body: '', status: 404 };
+  }
+
+  return { body: null, status: ContinuationToken ? 206 : 204 };
 }

--- a/test/it/post.spec.js
+++ b/test/it/post.spec.js
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import assert from 'node:assert';
+
+import worker from '../../src/index.js';
+import {
+  S3Client,
+  ListObjectsV2Command,
+  CopyObjectCommand,
+} from '@aws-sdk/client-s3';
+import { mockClient } from 'aws-sdk-client-mock';
+
+const s3Mock = mockClient(S3Client);
+
+describe('POST/PUT HTTP Requests', () => {
+  beforeEach(() => {
+    s3Mock.reset();
+  });
+
+  for (const method of ['POST', 'PUT']) {
+    describe(method, () => {
+      describe('/copy', () => {
+        it('will support copying a long list of files as per expected browser interaction', async () => {
+          const env = {
+            DA_CONFIG: {
+              get() {
+                return undefined;
+              }
+            }
+          };
+
+          const initialContents = [];
+          for (let i = 0; i < 1500; i++) {
+            initialContents.push({ Key: `mydir/page${i}.html` });
+          }
+
+          s3Mock.on(CopyObjectCommand).callsFake(() => { return true });
+          s3Mock
+            .on(ListObjectsV2Command, { Bucket: 'wknd-content', Prefix: 'mydir/' })
+            .resolves({ Contents: initialContents.splice(0, 500), NextContinuationToken: 'token1' });
+
+          s3Mock
+            .on(ListObjectsV2Command, { Bucket: 'wknd-content', Prefix: 'mydir/', ContinuationToken: 'token1' })
+            .resolves({ Contents: initialContents.splice(0, 500), NextContinuationToken: 'token2' });
+
+          s3Mock
+            .on(ListObjectsV2Command, { Bucket: 'wknd-content', Prefix: 'mydir/', ContinuationToken: 'token2' })
+            .resolves({ Contents: initialContents.splice(0, 500) });
+
+          let form = new FormData();
+          form.append('destination', '/mydir/newdir');
+          let opts = { body: form, method };
+          let req = new Request('https://admin.da.live/copy/wknd/mydir', opts);
+
+          // First call
+          let resp = await worker.fetch(req, env);
+          assert.strictEqual(resp.status, 206);
+          let body = await resp.json();
+          let remaining = body.remaining;
+          assert.strictEqual(remaining.length, 1000);
+
+          // Second call
+          form = new FormData();
+          form.append('destination', '/mydir/newdir');
+          form.append('remaining', JSON.stringify(remaining));
+          opts = { body: form, method };
+          req = new Request('https://admin.da.live/copy/wknd/mydir', opts);
+          resp = await worker.fetch(req, env);
+          assert.strictEqual(resp.status, 206);
+          body = await resp.json();
+          remaining = body.remaining;
+          assert.strictEqual(remaining.length, 500);
+
+          // Final call
+          form = new FormData();
+          form.append('destination', '/mydir/newdir');
+          form.append('remaining', JSON.stringify(remaining));
+          opts = { body: form, method };
+          req = new Request('https://admin.da.live/copy/wknd/mydir', opts);
+          resp = await worker.fetch(req, env);
+          assert.strictEqual(resp.status, 204);
+
+        });
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Description

Copy & Delete now return a specific status code based on resulting state:
* 204 if the operation is complete
* 206 if there is more to process.

Copy Operation will return a list of remaining Keys that need to be updated. If present, will not query system again, will just operate on the list. If still more remain after sub-process limit is reached, repeat the call via client.

Delete operation can simply be called again and again until a 204 response is returned.


## Related Issue

Fixes #79 

## How Has This Been Tested?

Added unit tests, also added functional/integration test as expected by browser.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
