### PR TITLE
Copy perf redux2

### DIFF
--- a/src/helpers/delete.js
+++ b/src/helpers/delete.js
@@ -9,14 +9,14 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-export default async function copyHelper(req, daCtx) {
-  const formData = await req.formData();
-  if (!formData) return {};
-  const fullDest = formData.get('destination');
-  const continuationToken = formData.get('continuation-token');
-  const lower = fullDest.slice(1).toLowerCase();
-  const sanitized = lower.endsWith('/') ? lower.slice(0, -1) : lower;
-  const destination = sanitized.split('/').slice(1).join('/');
-  const source = daCtx.key;
-  return { source, destination, continuationToken };
+
+export default async function deleteHelper(req) {
+  try {
+    const formData = await req.formData();
+    if (!formData) return {};
+    const continuationToken = formData.get('continuation-token');
+    return { continuationToken };
+  } catch {
+    return {};
+  }
 }

--- a/src/routes/source.js
+++ b/src/routes/source.js
@@ -14,6 +14,7 @@ import putObject from '../storage/object/put.js';
 import deleteObjects from '../storage/object/delete.js';
 
 import putHelper from '../helpers/source.js';
+import deleteHelper from '../helpers/delete.js';
 
 async function invalidateCollab(api, url, env) {
   const invPath = `/api/v1/${api}?doc=${url}`;
@@ -23,8 +24,9 @@ async function invalidateCollab(api, url, env) {
   await env.dacollab.fetch(invURL);
 }
 
-export async function deleteSource({ env, daCtx }) {
-  return /* await */ deleteObjects(env, daCtx);
+export async function deleteSource({ req, env, daCtx }) {
+  const details = await deleteHelper(req);
+  return /* await */ deleteObjects(env, daCtx, details);
 }
 
 export async function postSource({ req, env, daCtx }) {

--- a/src/storage/object/delete.js
+++ b/src/storage/object/delete.js
@@ -12,19 +12,11 @@
 import {
   S3Client,
   DeleteObjectCommand,
-  ListObjectsV2Command,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-
 import getS3Config from '../utils/config.js';
 import { postObjectVersionWithLabel } from '../version/put.js';
-
-function buildInput(org, key) {
-  return {
-    Bucket: `${org}-content`,
-    Prefix: `${key}/`,
-  };
-}
+import { listCommand } from '../utils/list.js';
 
 async function invalidateCollab(api, url, env) {
   const invPath = `/api/v1/${api}?doc=${url}`;
@@ -59,40 +51,15 @@ export async function deleteObject(client, daCtx, Key, env, isMove = false) {
   return resp;
 }
 
-export default async function deleteObjects(env, daCtx) {
+export default async function deleteObjects(env, daCtx, details) {
   const config = getS3Config(env);
   const client = new S3Client(config);
-  const input = buildInput(daCtx.org, daCtx.key);
 
-  let ContinuationToken;
+  const { sourceKeys, continuationToken } = await listCommand(daCtx, details, client);
 
-  // The input prefix has a forward slash to prevent (drafts + drafts-new, etc.).
-  // Which means the list will only pickup children. This adds to the initial list.
-  const sourceKeys = [daCtx.key, `${daCtx.key}.props`];
+  await Promise.all(sourceKeys.map(async (key) => {
+    await deleteObject(client, daCtx.org, key, env);
+  }));
 
-  do {
-    try {
-      const command = new ListObjectsV2Command({ ...input, ContinuationToken });
-      const resp = await client.send(command);
-
-      const { Contents = [], NextContinuationToken } = resp;
-      sourceKeys.push(...Contents.map(({ Key }) => Key));
-
-      await Promise.all(
-        new Array(1).fill(null).map(async () => {
-          while (sourceKeys.length) {
-            await deleteObject(client, daCtx, sourceKeys.pop(), env);
-          }
-        }),
-      );
-
-      ContinuationToken = NextContinuationToken;
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.log(e);
-      return { body: '', status: 404 };
-    }
-  } while (ContinuationToken);
-
-  return { body: null, status: 204 };
+  return { body: JSON.stringify({ continuationToken }), status: 200 };
 }

--- a/src/storage/object/delete.js
+++ b/src/storage/object/delete.js
@@ -61,5 +61,8 @@ export default async function deleteObjects(env, daCtx, details) {
     await deleteObject(client, daCtx.org, key, env);
   }));
 
-  return { body: JSON.stringify({ continuationToken }), status: 200 };
+  if (continuationToken) {
+    return { body: JSON.stringify({ continuationToken }), status: 206 };
+  }
+  return { status: 204 };
 }

--- a/src/storage/utils/list.js
+++ b/src/storage/utils/list.js
@@ -82,6 +82,13 @@ function buildInput(org, key) {
   };
 }
 
+/**
+ * Lists a files in a bucket under the specified key.
+ * @param {DaCtx} daCtx the DA Context
+ * @param {Object} details contains any prevous Continuation token
+ * @param s3client
+ * @return {Promise<{sourceKeys: String[], continuationToken: String}>}
+ */
 export async function listCommand(daCtx, details, s3client) {
   // There's no need to use the list command if the item has an extension
   if (daCtx.ext) return { sourceKeys: [daCtx.key] };
@@ -94,16 +101,12 @@ export async function listCommand(daCtx, details, s3client) {
   const sourceKeys = [];
   if (!continuationToken) sourceKeys.push(daCtx.key, `${daCtx.key}.props`);
 
-  try {
-    const commandInput = { ...input, ContinuationToken: continuationToken };
-    const command = new ListObjectsV2Command(commandInput);
-    const resp = await s3client.send(command);
+  const commandInput = { ...input, ContinuationToken: continuationToken };
+  const command = new ListObjectsV2Command(commandInput);
+  const resp = await s3client.send(command);
 
-    const { Contents = [], NextContinuationToken } = resp;
-    sourceKeys.push(...Contents.map(({ Key }) => Key));
+  const { Contents = [], NextContinuationToken } = resp;
+  sourceKeys.push(...Contents.map(({ Key }) => Key));
 
-    return { sourceKeys, continuationToken: NextContinuationToken };
-  } catch (e) {
-    return { body: '', status: 404 };
-  }
+  return { sourceKeys, continuationToken: NextContinuationToken };
 }

--- a/src/storage/utils/list.js
+++ b/src/storage/utils/list.js
@@ -9,6 +9,10 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import {
+  ListObjectsV2Command,
+} from '@aws-sdk/client-s3';
+
 export default function formatList(resp, daCtx) {
   function compare(a, b) {
     if (a.name < b.name) return -1;
@@ -68,4 +72,38 @@ export default function formatList(resp, daCtx) {
   }
 
   return combined.sort(compare);
+}
+
+function buildInput(org, key) {
+  return {
+    Bucket: `${org}-content`,
+    Prefix: `${key}/`,
+    MaxKeys: 900,
+  };
+}
+
+export async function listCommand(daCtx, details, s3client) {
+  // There's no need to use the list command if the item has an extension
+  if (daCtx.ext) return { sourceKeys: [daCtx.key] };
+
+  const input = buildInput(daCtx.org, daCtx.key);
+  const { continuationToken } = details;
+
+  // The input prefix has a forward slash to prevent (drafts + drafts-new, etc.).
+  // Which means the list will only pickup children. This adds to the initial list.
+  const sourceKeys = [];
+  if (!continuationToken) sourceKeys.push(daCtx.key, `${daCtx.key}.props`);
+
+  try {
+    const commandInput = { ...input, ContinuationToken: continuationToken };
+    const command = new ListObjectsV2Command(commandInput);
+    const resp = await s3client.send(command);
+
+    const { Contents = [], NextContinuationToken } = resp;
+    sourceKeys.push(...Contents.map(({ Key }) => Key));
+
+    return { sourceKeys, continuationToken: NextContinuationToken };
+  } catch (e) {
+    return { body: '', status: 404 };
+  }
 }

--- a/test/storage/object/copy.test.js
+++ b/test/storage/object/copy.test.js
@@ -26,7 +26,7 @@ describe('Object copy', () => {
     const ctx = {
       org: 'foo',
       key: 'mydir',
-      users: [{email: 'haha@foo.com'}],
+      users: [{ email: 'haha@foo.com' }],
     };
 
     const details = {
@@ -37,60 +37,214 @@ describe('Object copy', () => {
     assert.strictEqual(resp.status, 409);
   });
 
-  it('Copies a file', async () => {
-    s3Mock.on(ListObjectsV2Command).resolves({ Contents: [{ Key: 'mydir/xyz.html' }] });
+  describe('single file context', () => {
+    it('Copies a file', async () => {
+      s3Mock.on(ListObjectsV2Command).resolves({ Contents: [{ Key: 'mydir/xyz.html' }] });
 
-    const s3Sent = [];
-    s3Mock.on(CopyObjectCommand).callsFake((input => {
-      s3Sent.push(input);
-    }));
+      const s3Sent = [];
+      s3Mock.on(CopyObjectCommand).callsFake((input => {
+        s3Sent.push(input);
+      }));
 
-    const ctx = {
-      org: 'foo',
-      key: 'mydir',
-      users: [{email: 'haha@foo.com'}],
-    };
-    const details = {
-      source: 'mydir',
-      destination: 'mydir/newdir',
-    };
-    await copyObject({}, ctx, details, false);
+      const ctx = {
+        org: 'foo',
+        key: 'mydir',
+        users: [{ email: 'haha@foo.com' }],
+      };
+      const details = {
+        source: 'mydir',
+        destination: 'mydir/newdir',
+      };
+      await copyObject({}, ctx, details, false);
 
-    assert.strictEqual(s3Sent.length, 3);
-    const input = s3Sent[2];
-    assert.strictEqual(input.Bucket, 'foo-content');
-    assert.strictEqual(input.CopySource, 'foo-content/mydir/xyz.html');
-    assert.strictEqual(input.Key, 'mydir/newdir/xyz.html');
+      assert.strictEqual(s3Sent.length, 3);
+      const input = s3Sent[2];
+      assert.strictEqual(input.Bucket, 'foo-content');
+      assert.strictEqual(input.CopySource, 'foo-content/mydir/xyz.html');
+      assert.strictEqual(input.Key, 'mydir/newdir/xyz.html');
 
-    const md = input.Metadata;
-    assert(md.ID, "ID should be set");
-    assert(md.Version, "Version should be set");
-    assert.strictEqual(typeof(md.Timestamp), 'string', 'Timestamp should be set as a string');
-    assert.strictEqual(md.Users, '[{"email":"haha@foo.com"}]');
-    assert.strictEqual(md.Path, 'mydir/newdir/xyz.html');
+      const md = input.Metadata;
+      assert(md.ID, "ID should be set");
+      assert(md.Version, "Version should be set");
+      assert.strictEqual(typeof (md.Timestamp), 'string', 'Timestamp should be set as a string');
+      assert.strictEqual(md.Users, '[{"email":"haha@foo.com"}]');
+      assert.strictEqual(md.Path, 'mydir/newdir/xyz.html');
+    });
+
+    it('Copies a file for rename', async () => {
+      s3Mock.on(ListObjectsV2Command).resolves({ Contents: [{ Key: 'mydir/dir1/myfile.html' }] });
+
+      const s3Sent = [];
+      s3Mock.on(CopyObjectCommand).callsFake((input => {
+        s3Sent.push(input);
+      }));
+
+      const ctx = { key: 'mydir/dir1', org: 'testorg' };
+      const details = {
+        source: 'mydir/dir1',
+        destination: 'mydir/dir2',
+      };
+      await copyObject({}, ctx, details, true);
+
+
+      assert.strictEqual(s3Sent.length, 3);
+      const input = s3Sent[2];
+      assert.strictEqual(input.Bucket, 'testorg-content');
+      assert.strictEqual(input.CopySource, 'testorg-content/mydir/dir1/myfile.html');
+      assert.strictEqual(input.Key, 'mydir/dir2/myfile.html');
+      assert.ifError(input.Metadata);
+    });
   });
 
-  it('Copies a file for rename', async () => {
-    s3Mock.on(ListObjectsV2Command).resolves({ Contents: [{ Key: 'mydir/dir1/myfile.html' }] });
+  describe('Copies a list of files', async () => {
+    it('handles no continuation token', async () => {
+      s3Mock.on(ListObjectsV2Command).resolves({
+        Contents: [{ Key: 'mydir/xyz.html' }],
+      });
 
-    const s3Sent = [];
-    s3Mock.on(CopyObjectCommand).callsFake((input => {
-      s3Sent.push(input);
-    }));
+      const s3Sent = [];
+      s3Mock.on(CopyObjectCommand).callsFake((input => {
+        s3Sent.push(input);
+      }));
 
-    const ctx = { key: 'mydir/dir1', org: 'testorg' };
-    const details = {
-      source: 'mydir/dir1',
-      destination: 'mydir/dir2',
-    };
-    await copyObject({}, ctx, details, true);
+      const ctx = {
+        org: 'foo',
+        key: 'mydir',
+        users: [{ email: 'haha@foo.com' }],
+      };
+      const details = {
+        source: 'mydir',
+        destination: 'mydir/newdir',
+      };
+      const resp = await copyObject({}, ctx, details, false);
+      assert.strictEqual(resp.status, 204);
+      assert.strictEqual(resp.body, undefined);
+      assert.strictEqual(s3Sent.length, 3);
+    });
+
+    it('handles a list with continuation token', async () => {
+      const DA_JOBS = {};
+      const env = {
+        DA_JOBS: {
+          put(key, value) {
+            DA_JOBS[key] = value;
+          }
+        }
+      }
+      s3Mock.on(ListObjectsV2Command)
+        .resolves({
+          Contents: [{ Key: 'mydir/xyz.html' }],
+          NextContinuationToken: 'token',
+        });
+
+      s3Mock.on(ListObjectsV2Command, { ContinuationToken: 'token' })
+        .resolves({
+          Contents: [{ Key: 'mydir/abc.html' }],
+        });
 
 
-    assert.strictEqual(s3Sent.length, 3);
-    const input = s3Sent[2];
-    assert.strictEqual(input.Bucket, 'testorg-content');
-    assert.strictEqual(input.CopySource, 'testorg-content/mydir/dir1/myfile.html');
-    assert.strictEqual(input.Key, 'mydir/dir2/myfile.html');
-    assert.ifError(input.Metadata);
+      const s3Sent = [];
+      s3Mock.on(CopyObjectCommand).callsFake((input => {
+        s3Sent.push(input);
+      }));
+
+      const ctx = {
+        org: 'foo',
+        key: 'mydir',
+        users: [{ email: 'haha@foo.com' }],
+      };
+      const details = {
+        source: 'mydir',
+        destination: 'mydir/newdir',
+      };
+      const resp = await copyObject(env, ctx, details, false);
+      assert.strictEqual(resp.status, 206);
+      const { continuationToken } = JSON.parse(resp.body);
+
+      assert.deepStrictEqual(JSON.parse(DA_JOBS[continuationToken]), ['mydir/abc.html']);
+      assert.strictEqual(s3Sent.length, 3);
+    });
+
+    it('handles a continuation token w/ more', async () => {
+      const continuationToken = 'copy-mydir-mydir/newdir-uuid';
+      const remaining = [];
+      for (let i = 0; i < 900; i++) {
+        remaining.push(`mydir/file${i}.html`);
+      }
+      remaining.push('mydir/abc.html');
+
+      const DA_JOBS = {};
+      DA_JOBS[continuationToken] = remaining;
+      const env = {
+        DA_JOBS: {
+          put(key, value) {
+            DA_JOBS[key] = value;
+          },
+          get(key) {
+            return DA_JOBS[key];
+          }
+        }
+      }
+
+      const ctx = {
+        org: 'foo',
+        key: 'mydir',
+        users: [{ email: 'haha@foo.com' }],
+      };
+      const details = {
+        source: 'mydir',
+        destination: 'mydir/newdir',
+        continuationToken,
+      };
+      const s3Sent = [];
+      s3Mock.on(CopyObjectCommand).callsFake((input => {
+        s3Sent.push(input);
+      }));
+
+
+      const resp = await copyObject(env, ctx, details, false);
+      assert.strictEqual(resp.status, 206);
+      assert.deepStrictEqual(JSON.parse(resp.body), { continuationToken });
+      assert.strictEqual(s3Sent.length, 900);
+      assert.deepStrictEqual(JSON.parse(DA_JOBS[continuationToken]), ['mydir/abc.html']);
+    });
+
+    it('handles continuation token w/o more', async () => {
+      const continuationToken = 'copy-mydir-mydir/newdir-uuid';
+      const remaining = ['mydir/abc.html'];
+
+      const DA_JOBS = {};
+      DA_JOBS[continuationToken] = remaining;
+      const env = {
+        DA_JOBS: {
+          get(key) {
+            return DA_JOBS[key];
+          },
+          delete(key) {
+            delete DA_JOBS[key];
+          }
+        }
+      }
+
+      const ctx = {
+        org: 'foo',
+        key: 'mydir',
+        users: [{ email: 'haha@foo.com' }],
+      };
+      const details = {
+        source: 'mydir',
+        destination: 'mydir/newdir',
+        continuationToken,
+      };
+      const s3Sent = [];
+      s3Mock.on(CopyObjectCommand).callsFake((input => {
+        s3Sent.push(input);
+      }));
+      const resp = await copyObject(env, ctx, details, false);
+      assert.strictEqual(resp.status, 204);
+      assert.ifError(resp.body);
+      assert.strictEqual(s3Sent.length, 1);
+      assert.ifError(DA_JOBS[continuationToken]);
+    });
   });
 });

--- a/test/storage/object/copy.test.js
+++ b/test/storage/object/copy.test.js
@@ -23,11 +23,17 @@ describe('Object copy', () => {
   });
 
   it('does not allow copying to the same location', async () => {
+    const ctx = {
+      org: 'foo',
+      key: 'mydir',
+      users: [{email: 'haha@foo.com'}],
+    };
+
     const details = {
       source: 'mydir',
       destination: 'mydir',
     };
-    const resp = await copyObject({}, {}, details, false);
+    const resp = await copyObject({}, ctx, details, false);
     assert.strictEqual(resp.status, 409);
   });
 
@@ -41,6 +47,7 @@ describe('Object copy', () => {
 
     const ctx = {
       org: 'foo',
+      key: 'mydir',
       users: [{email: 'haha@foo.com'}],
     };
     const details = {
@@ -50,7 +57,7 @@ describe('Object copy', () => {
     await copyObject({}, ctx, details, false);
 
     assert.strictEqual(s3Sent.length, 3);
-    const input = s3Sent[0];
+    const input = s3Sent[2];
     assert.strictEqual(input.Bucket, 'foo-content');
     assert.strictEqual(input.CopySource, 'foo-content/mydir/xyz.html');
     assert.strictEqual(input.Key, 'mydir/newdir/xyz.html');
@@ -71,7 +78,7 @@ describe('Object copy', () => {
       s3Sent.push(input);
     }));
 
-    const ctx = { org: 'testorg' };
+    const ctx = { key: 'mydir/dir1', org: 'testorg' };
     const details = {
       source: 'mydir/dir1',
       destination: 'mydir/dir2',
@@ -80,7 +87,7 @@ describe('Object copy', () => {
 
 
     assert.strictEqual(s3Sent.length, 3);
-    const input = s3Sent[0];
+    const input = s3Sent[2];
     assert.strictEqual(input.Bucket, 'testorg-content');
     assert.strictEqual(input.CopySource, 'testorg-content/mydir/dir1/myfile.html');
     assert.strictEqual(input.Key, 'mydir/dir2/myfile.html');

--- a/test/storage/object/delete.test.js
+++ b/test/storage/object/delete.test.js
@@ -11,207 +11,288 @@
  */
 import assert from 'node:assert';
 import esmock from 'esmock';
+import { mockClient } from 'aws-sdk-client-mock';
+import { DeleteObjectCommand, ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3';
+
+const s3Mock = mockClient(S3Client);
+
 
 describe('Object delete', () => {
-  it('Delete a file', async () => {
-    const collabCalled = []
-    const dacollab = { fetch: (u) => collabCalled.push(u) };
+  beforeEach(() => {
+    s3Mock.reset();
+  });
 
-    const client = {};
-    const env = { dacollab };
-    const daCtx = {
-      origin: 'https://admin.da.live',
-      org: 'testorg',
-    };
+  describe('single context', () => {
+    it('Delete a file', async () => {
+      const collabCalled = []
+      const dacollab = { fetch: (u) => collabCalled.push(u) };
 
-    const postObjVerCalled = [];
-    const mockPostObjectVersion = async (l, e, c) => {
-      if (l === 'Deleted' && e === env && c === daCtx) {
-        postObjVerCalled.push('postObjectVersionWithLabel');
-        return {status: 201};
-      }
-    };
-
-    const deleteURL = 'https://localhost:9876/foo/bar.html';
-    const mockSignedUrl = async (cl, cm) => {
-      if (cl === client
-        && cm.constructor.toString().includes('DeleteObjectCommand')) {
-        return deleteURL;
-      }
-    };
-
-    const { deleteObject } = await esmock(
-      '../../../src/storage/object/delete.js', {
-        '../../../src/storage/version/put.js': {
-          postObjectVersionWithLabel: mockPostObjectVersion,
-        },
-        '@aws-sdk/s3-request-presigner': {
-          getSignedUrl: mockSignedUrl,
-        }
-      }
-    );
-
-    const savedFetch = globalThis.fetch;
-    try {
-      globalThis.fetch = async (url, opts) => {
-        assert.equal(deleteURL, url);
-        assert.equal('DELETE', opts.method);
-        return {status: 204};
+      const client = {};
+      const env = { dacollab };
+      const daCtx = {
+        origin: 'https://admin.da.live',
+        org: 'testorg',
       };
 
-      const resp = await deleteObject(client, daCtx, 'foo/bar.html', env);
-      assert.equal(204, resp.status);
-      assert.deepStrictEqual(['postObjectVersionWithLabel'], postObjVerCalled);
-      assert.deepStrictEqual(
-        ['https://localhost/api/v1/deleteadmin?doc=https://admin.da.live/source/testorg/foo/bar.html'],
-        collabCalled
+      const postObjVerCalled = [];
+      const mockPostObjectVersion = async (l, e, c) => {
+        if (l === 'Deleted' && e === env && c === daCtx) {
+          postObjVerCalled.push('postObjectVersionWithLabel');
+          return { status: 201 };
+        }
+      };
+
+      const deleteURL = 'https://localhost:9876/foo/bar.html';
+      const mockSignedUrl = async (cl, cm) => {
+        if (cl === client
+          && cm.constructor.toString().includes('DeleteObjectCommand')) {
+          return deleteURL;
+        }
+      };
+
+      const { deleteObject } = await esmock(
+        '../../../src/storage/object/delete.js', {
+          '../../../src/storage/version/put.js': {
+            postObjectVersionWithLabel: mockPostObjectVersion,
+          },
+          '@aws-sdk/s3-request-presigner': {
+            getSignedUrl: mockSignedUrl,
+          }
+        }
       );
-    } finally {
-      globalThis.fetch = savedFetch;
-    }
-  });
 
-  it('Delete dir', async() => {
-    const client = {};
-    const daCtx = {};
-    const env = {};
+      const savedFetch = globalThis.fetch;
+      try {
+        globalThis.fetch = async (url, opts) => {
+          assert.equal(deleteURL, url);
+          assert.equal('DELETE', opts.method);
+          return { status: 204 };
+        };
 
-    const postObjVerCalled = [];
-    const mockPostObjectVersion = async (l, e, c) => {
-      if (l === 'Moved' && e === env && c === daCtx) {
-        postObjVerCalled.push('postObjectVersionWithLabel');
-        return {status: 201};
+        const resp = await deleteObject(client, daCtx, 'foo/bar.html', env);
+        assert.equal(204, resp.status);
+        assert.deepStrictEqual(['postObjectVersionWithLabel'], postObjVerCalled);
+        assert.deepStrictEqual(
+          ['https://localhost/api/v1/deleteadmin?doc=https://admin.da.live/source/testorg/foo/bar.html'],
+          collabCalled
+        );
+      } finally {
+        globalThis.fetch = savedFetch;
       }
-    };
+    });
 
-    const deleteURL = 'https://localhost:9876/a/b/c/d';
-    const mockSignedUrl = async (cl, cm) => {
-      if (cl === client
-        && cm.constructor.toString().includes('DeleteObjectCommand')) {
-        return deleteURL;
-      }
-    };
+    it('Delete dir', async () => {
+      const client = {};
+      const daCtx = {};
+      const env = {};
 
-    const { deleteObject } = await esmock(
-      '../../../src/storage/object/delete.js', {
-        '../../../src/storage/version/put.js': {
-          postObjectVersionWithLabel: mockPostObjectVersion,
-        },
-        '@aws-sdk/s3-request-presigner': {
-          getSignedUrl: mockSignedUrl,
+      const postObjVerCalled = [];
+      const mockPostObjectVersion = async (l, e, c) => {
+        if (l === 'Moved' && e === env && c === daCtx) {
+          postObjVerCalled.push('postObjectVersionWithLabel');
+          return { status: 201 };
         }
-      }
-    );
-
-    const savedFetch = globalThis.fetch;
-    try {
-      globalThis.fetch = async (url, opts) => {
-        assert.equal(deleteURL, url);
-        assert.equal('DELETE', opts.method);
-        return {status: 204};
       };
 
-      const resp = await deleteObject(client, daCtx, 'd', env, true);
-      assert.equal(204, resp.status);
-      assert.deepStrictEqual([], postObjVerCalled);
-    } finally {
-      globalThis.fetch = savedFetch;
-    }
-  });
-
-  it('Delete properties file', async() => {
-    const client = {};
-    const daCtx = {};
-    const env = {};
-
-    const postObjVerCalled = [];
-    const mockPostObjectVersion = async (l, e, c) => {
-      if (l === 'Moved' && e === env && c === daCtx) {
-        postObjVerCalled.push('postObjectVersionWithLabel');
-        return {status: 201};
-      }
-    };
-
-    const deleteURL = 'https://localhost:9876/a/b/c/d.props';
-    const mockSignedUrl = async (cl, cm) => {
-      if (cl === client
-        && cm.constructor.toString().includes('DeleteObjectCommand')) {
-        return deleteURL;
-      }
-    };
-
-    const { deleteObject } = await esmock(
-      '../../../src/storage/object/delete.js', {
-        '../../../src/storage/version/put.js': {
-          postObjectVersionWithLabel: mockPostObjectVersion,
-        },
-        '@aws-sdk/s3-request-presigner': {
-          getSignedUrl: mockSignedUrl,
+      const deleteURL = 'https://localhost:9876/a/b/c/d';
+      const mockSignedUrl = async (cl, cm) => {
+        if (cl === client
+          && cm.constructor.toString().includes('DeleteObjectCommand')) {
+          return deleteURL;
         }
-      }
-    );
-
-    const savedFetch = globalThis.fetch;
-    try {
-      globalThis.fetch = async (url, opts) => {
-        assert.equal(deleteURL, url);
-        assert.equal('DELETE', opts.method);
-        return {status: 204};
       };
 
-      const resp = await deleteObject(client, daCtx, 'd.props', env, true);
-      assert.equal(204, resp.status);
-      assert.deepStrictEqual([], postObjVerCalled);
-    } finally {
-      globalThis.fetch = savedFetch;
-    }
-  });
-
-  it('Move a non-doc resource', async () => {
-    const client = {};
-    const daCtx = {};
-    const env = {};
-
-    const postObjVerCalled = [];
-    const mockPostObjectVersion = async (l, e, c) => {
-      if (l === 'Moved' && e === env && c === daCtx) {
-        postObjVerCalled.push('postObjectVersionWithLabel');
-        return {status: 201};
-      }
-    };
-
-    const deleteURL = 'https://localhost:9876/aha.png';
-    const mockSignedUrl = async (cl, cm) => {
-      if (cl === client
-        && cm.constructor.toString().includes('DeleteObjectCommand')) {
-        return deleteURL;
-      }
-    };
-
-    const { deleteObject } = await esmock(
-      '../../../src/storage/object/delete.js', {
-        '../../../src/storage/version/put.js': {
-          postObjectVersionWithLabel: mockPostObjectVersion,
-        },
-        '@aws-sdk/s3-request-presigner': {
-          getSignedUrl: mockSignedUrl,
+      const { deleteObject } = await esmock(
+        '../../../src/storage/object/delete.js', {
+          '../../../src/storage/version/put.js': {
+            postObjectVersionWithLabel: mockPostObjectVersion,
+          },
+          '@aws-sdk/s3-request-presigner': {
+            getSignedUrl: mockSignedUrl,
+          }
         }
-      }
-    );
+      );
 
-    const savedFetch = globalThis.fetch;
-    try {
-      globalThis.fetch = async (url, opts) => {
-        assert.equal(deleteURL, url);
-        assert.equal('DELETE', opts.method);
-        return {status: 204};
+      const savedFetch = globalThis.fetch;
+      try {
+        globalThis.fetch = async (url, opts) => {
+          assert.equal(deleteURL, url);
+          assert.equal('DELETE', opts.method);
+          return { status: 204 };
+        };
+
+        const resp = await deleteObject(client, daCtx, 'd', env, true);
+        assert.equal(204, resp.status);
+        assert.deepStrictEqual([], postObjVerCalled);
+      } finally {
+        globalThis.fetch = savedFetch;
+      }
+    });
+
+    it('Delete properties file', async () => {
+      const client = {};
+      const daCtx = {};
+      const env = {};
+
+      const postObjVerCalled = [];
+      const mockPostObjectVersion = async (l, e, c) => {
+        if (l === 'Moved' && e === env && c === daCtx) {
+          postObjVerCalled.push('postObjectVersionWithLabel');
+          return { status: 201 };
+        }
       };
 
-      const resp = await deleteObject(client, daCtx, 'aha.png', env, true);
-      assert.equal(204, resp.status);
-      assert.deepStrictEqual(['postObjectVersionWithLabel'], postObjVerCalled);
-    } finally {
-      globalThis.fetch = savedFetch;
-    }
+      const deleteURL = 'https://localhost:9876/a/b/c/d.props';
+      const mockSignedUrl = async (cl, cm) => {
+        if (cl === client
+          && cm.constructor.toString().includes('DeleteObjectCommand')) {
+          return deleteURL;
+        }
+      };
+
+      const { deleteObject } = await esmock(
+        '../../../src/storage/object/delete.js', {
+          '../../../src/storage/version/put.js': {
+            postObjectVersionWithLabel: mockPostObjectVersion,
+          },
+          '@aws-sdk/s3-request-presigner': {
+            getSignedUrl: mockSignedUrl,
+          }
+        }
+      );
+
+      const savedFetch = globalThis.fetch;
+      try {
+        globalThis.fetch = async (url, opts) => {
+          assert.equal(deleteURL, url);
+          assert.equal('DELETE', opts.method);
+          return { status: 204 };
+        };
+
+        const resp = await deleteObject(client, daCtx, 'd.props', env, true);
+        assert.equal(204, resp.status);
+        assert.deepStrictEqual([], postObjVerCalled);
+      } finally {
+        globalThis.fetch = savedFetch;
+      }
+    });
+
+    it('Move a non-doc resource', async () => {
+      const client = {};
+      const daCtx = {};
+      const env = {};
+
+      const postObjVerCalled = [];
+      const mockPostObjectVersion = async (l, e, c) => {
+        if (l === 'Moved' && e === env && c === daCtx) {
+          postObjVerCalled.push('postObjectVersionWithLabel');
+          return { status: 201 };
+        }
+      };
+
+      const deleteURL = 'https://localhost:9876/aha.png';
+      const mockSignedUrl = async (cl, cm) => {
+        if (cl === client
+          && cm.constructor.toString().includes('DeleteObjectCommand')) {
+          return deleteURL;
+        }
+      };
+
+      const { deleteObject } = await esmock(
+        '../../../src/storage/object/delete.js', {
+          '../../../src/storage/version/put.js': {
+            postObjectVersionWithLabel: mockPostObjectVersion,
+          },
+          '@aws-sdk/s3-request-presigner': {
+            getSignedUrl: mockSignedUrl,
+          }
+        }
+      );
+
+      const savedFetch = globalThis.fetch;
+      try {
+        globalThis.fetch = async (url, opts) => {
+          assert.equal(deleteURL, url);
+          assert.equal('DELETE', opts.method);
+          return { status: 204 };
+        };
+
+        const resp = await deleteObject(client, daCtx, 'aha.png', env, true);
+        assert.equal(204, resp.status);
+        assert.deepStrictEqual(['postObjectVersionWithLabel'], postObjVerCalled);
+      } finally {
+        globalThis.fetch = savedFetch;
+      }
+    });
+  });
+
+  describe('multiple files context', () => {
+    it('Handles no continuation', async () => {
+      const daCtx = {
+        org: 'testorg',
+        key: 'foo/bar.html',
+      };
+      const env = {
+        dacollab: {
+          fetch: () => {
+          }
+        },
+      };
+      const mockPostObjectVersion = async () => ({ status: 201 });
+      const mockSignedUrl = async () => 'http://localhost:8080/test/';
+      const deleteObjects = await esmock(
+        '../../../src/storage/object/delete.js',
+        {
+          '../../../src/storage/version/put.js': {
+            postObjectVersionWithLabel: mockPostObjectVersion,
+          },
+          '@aws-sdk/s3-request-presigner': {
+            getSignedUrl: mockSignedUrl,
+          }
+        },
+        {
+          import: {
+            fetch: async () => ({ status: 200 }),
+          }
+        }
+      );
+      s3Mock.on(ListObjectsV2Command).resolves({ Contents: [{ Key: 'foo/bar.html' }] });
+      const resp = await deleteObjects(env, daCtx, {});
+      assert.strictEqual(resp.status, 204);
+    });
+
+    it('Handles continuation', async () => {
+      const daCtx = {
+        org: 'testorg',
+        key: 'foo/bar.html',
+      };
+      const env = {
+        dacollab: {
+          fetch: () => {
+          }
+        },
+      };
+      const mockPostObjectVersion = async () => ({ status: 201 });
+      const mockSignedUrl = async () => 'http://localhost:8080/test/';
+      const deleteObjects = await esmock(
+        '../../../src/storage/object/delete.js',
+        {
+          '../../../src/storage/version/put.js': {
+            postObjectVersionWithLabel: mockPostObjectVersion,
+          },
+          '@aws-sdk/s3-request-presigner': {
+            getSignedUrl: mockSignedUrl,
+          }
+        },
+        {
+          import: {
+            fetch: async () => ({ status: 200 }),
+          }
+        }
+      );
+      s3Mock.on(ListObjectsV2Command).resolves({ Contents: [{ Key: 'foo/bar.html' }], NextContinuationToken: 'token' });
+      const resp = await deleteObjects(env, daCtx, {});
+      assert.strictEqual(resp.status, 206);
+    });
   });
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,7 +10,8 @@ services = [
 
 kv_namespaces = [
   { binding = "DA_AUTH", id = "d6217b7c63ef40889583ba5c080c3908" },
-  { binding = "DA_CONFIG", id = "feb8618620bb4ca3a866f1c71adbe8ef" }
+  { binding = "DA_CONFIG", id = "feb8618620bb4ca3a866f1c71adbe8ef" },
+  { binding = "DA_JOBS", id = "0ba6184767b2470ea05a1d082f974134" }
 ]
 
 [env.stage]
@@ -22,7 +23,8 @@ services = [
 
 kv_namespaces = [
   { binding = "DA_AUTH", id = "21693f3b20f54fcbb850ddc8947335ba" },
-  { binding = "DA_CONFIG", id = "c44cb8dc69f041dc87c5aaef41b97df9" }
+  { binding = "DA_CONFIG", id = "c44cb8dc69f041dc87c5aaef41b97df9" },
+  { binding = "DA_JOBS", id = "87f20eee7ca542fd9fc80a1325722fa1" }
 ]
 
 
@@ -30,5 +32,6 @@ kv_namespaces = [
 vars = { ENVIRONMENT = "dev", DA_COLLAB = "http://localhost:4711" }
 kv_namespaces = [
   { binding = "DA_AUTH", id = "21693f3b20f54fcbb850ddc8947335ba" },
-  { binding = "DA_CONFIG", id = "c44cb8dc69f041dc87c5aaef41b97df9" }
+  { binding = "DA_CONFIG", id = "c44cb8dc69f041dc87c5aaef41b97df9" },
+  { binding = "DA_JOBS", id = "87f20eee7ca542fd9fc80a1325722fa1" }
 ]


### PR DESCRIPTION
## Description

Copy & Delete now return a specific status code based on resulting state:
* 204 if the operation is complete
* 206 if there is more to process.

Copy operation remaining keys are stored in KV, subsequent calls for that operation w/ continuation token will use the remaining list, updating KV as necessary if more remain.

Delete operation can simply be called again and again until a 204 response is returned.

## Related Issue

Fixes #79 

## How Has This Been Tested?

Added unit tests, also added functional/integration test as expected by browser.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
