### PR TITLE
Support org configuration with multiple sheets

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -66,8 +66,13 @@ export async function getUsers(req, env) {
 export async function isAuthorized(env, org, user) {
   if (!org) return true;
 
-  const props = await env.DA_CONFIG.get(org, { type: 'json' });
+  let props = await env.DA_CONFIG.get(org, { type: 'json' });
   if (!props) return true;
+
+  // When the data is a multi-sheet, it's one level deeper
+  if (props[':type'] === 'multi-sheet') {
+    props = props.data;
+  }
 
   const admins = props.data.reduce((acc, data) => {
     if (data.key === 'admin.role.all') acc.push(data.value);

--- a/test/utils/auth.test.js
+++ b/test/utils/auth.test.js
@@ -25,7 +25,7 @@ const {
   getUsers,
 } = await esmock('../../src/utils/auth.js', { jose, import: { fetch } });
 
-describe('Dark Alley auth', () => {
+describe('DA auth', () => {
   describe('is authorized', async () => {
     // There's nothing to protect if there is no org in the request
     it('authorized if no org', async () => {
@@ -56,6 +56,43 @@ describe('Dark Alley auth', () => {
     it('not authorized no user match', async () => {
       const authed = await isAuthorized(env, 'geometrixx', { email: 'chad@geometrixx.info' });
       assert.strictEqual(authed, false);
+    });
+
+    it('authorization multi sheet config', async () => {
+      const DA_CONFIG = {
+        'geometrixx': {
+          "total": 1,
+          "limit": 1,
+          "offset": 0,
+          "data": {
+            "data": [
+              {
+                "key": "admin.role.all",
+                "value": "aPaRKer@Geometrixx.Info"
+              }
+            ],
+            "otherdata": [
+              {
+                "key": "foo",
+                "value": "bar"
+              }
+            ],
+          },
+          ":type": "multi-sheet"
+        }
+      };
+      const env2 = {
+        DA_CONFIG: {
+          get: (name) => {
+            return DA_CONFIG[name];
+          },
+        }
+      };
+
+      assert(await isAuthorized(env2, 'wknd', { email: 'aparker@geometrixx.info' }));
+      assert(await isAuthorized(env2, 'geometrixx', { email: 'aparker@geometrixx.info' }));
+      assert(await isAuthorized(env, 'geometrixx', { email: 'ApaRkeR@geometrixx.info' }));
+      assert(!await isAuthorized(env, 'geometrixx', { email: 'chad@geometrixx.info' }));
     });
   });
 


### PR DESCRIPTION
## Related Issue

Org configuration can now be done in a single or multi sheet.

Fixes #93

Note that the sheet with the `admin` role configuration still needs to be called `data` as previously.

## How Has This Been Tested?

Locally with da-live/da-collab
Also added unit tests

## Screenshots
<img width="526" alt="Screenshot 2024-12-03 at 14 51 13" src="https://github.com/user-attachments/assets/17470744-d1d8-4ced-abb6-63442fef4166">


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:


- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
