### PR TITLE
Fix key passed to postObjectVersionWithLabel when deleting

### DIFF
--- a/src/storage/object/delete.js
+++ b/src/storage/object/delete.js
@@ -37,8 +37,8 @@ async function invalidateCollab(api, url, env) {
 export async function deleteObject(client, daCtx, Key, env, isMove = false) {
   const fname = Key.split('/').pop();
 
-  if (fname.includes('.') && !Key.endsWith('.props')) {
-    await postObjectVersionWithLabel(isMove ? 'Moved' : 'Deleted', env, daCtx);
+  if (fname.includes('.') && !fname.startsWith('.') && !fname.endsWith('.props')) {
+    await postObjectVersionWithLabel(isMove ? 'Moved' : 'Deleted', env, { org: daCtx.org, key: Key });
   }
 
   let resp;

--- a/test/storage/object/delete.test.js
+++ b/test/storage/object/delete.test.js
@@ -26,7 +26,7 @@ describe('Object delete', () => {
 
     const postObjVerCalled = [];
     const mockPostObjectVersion = async (l, e, c) => {
-      if (l === 'Deleted' && e === env && c === daCtx) {
+      if (l === 'Deleted' && e === env && c.key === 'foo/bar.html' && c.org ==='testorg') {
         postObjVerCalled.push('postObjectVersionWithLabel');
         return {status: 201};
       }
@@ -174,7 +174,7 @@ describe('Object delete', () => {
 
     const postObjVerCalled = [];
     const mockPostObjectVersion = async (l, e, c) => {
-      if (l === 'Moved' && e === env && c === daCtx) {
+      if (l === 'Moved' && e === env && c.key === 'aha.png') {
         postObjVerCalled.push('postObjectVersionWithLabel');
         return {status: 201};
       }


### PR DESCRIPTION
## Description

When deleting an object a version of it will be stored to make it possible to restore the deleted object if needed. The key of the object that is stored was wrong which caused errors.

## How Has This Been Tested?

* Tested locally with da-live/da-collab
* Updated unit tests

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
