### PR TITLE
Temporarily disable creating the version on rename

### DIFF
--- a/src/storage/object/copy.js
+++ b/src/storage/object/copy.js
@@ -77,7 +77,10 @@ export const copyFile = async (config, env, daCtx, sourceKey, details, isRename)
           type: original.contentType,
         });
       }
-      await postObjectVersionWithLabel('Moved', env, daCtx);
+      // We're doing a rename
+
+      // TODO when storing the version make sure to do it from the file that was where there before
+      // await postObjectVersionWithLabel('Moved', env, daCtx);
 
       const client = new S3Client(config);
       // This is a move so copy to the new location


### PR DESCRIPTION
## Description

Disable storing a version of the target on a rename that overwrites an existing file.
This will be re-enabled once storing a file on delete is re-enabled.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
