### PR TITLE
Upgrade to node 22 in github action

### DIFF
--- a/.github/workflows/install-lint-test.yaml
+++ b/.github/workflows/install-lint-test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Change the github action that runs 'Install, lint, and test' to use Node 22

## Motivation and Context

The tests in #108 are failing because of it: https://github.com/adobe/da-admin/actions/runs/12951434134/job/36126473932?pr=108#step:6:228

## How Has This Been Tested?

It _is_ the tests (but only on github).

## Types of changes

Just to the github action workflow.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
