### PR TITLE
Avoid duplicates in the acl identifiers

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -92,7 +92,7 @@ export async function getUsers(req, env) {
 }
 
 function getIdents(user) {
-  return (user.groups || [])
+  const idents = (user.groups || [])
     .flatMap((group) => [
       `${group.orgIdent}`,
       `${group.orgIdent}/${group.groupName}`,
@@ -100,6 +100,9 @@ function getIdents(user) {
     ])
     .concat(user.email)
     .filter((e) => e !== undefined);
+
+  // remove duplicates
+  return [...new Set(idents)];
 }
 
 export function getUserActions(pathLookup, user, target) {

--- a/test/utils/auth.test.js
+++ b/test/utils/auth.test.js
@@ -172,6 +172,11 @@ describe('DA auth', () => {
               "actions": "write",
             },
             {
+              "path": "/hark/hork/hoo",
+              "groups": "2345B0EA551D747",
+              "actions": "write",
+            },
+            {
               "path": "ACLTRACE",
               "groups": "joe@bloggs.org",
               "actions": "read",
@@ -292,6 +297,38 @@ describe('DA auth', () => {
           path: '/bar/+**',
           actions: [ 'read', 'write' ]
         }, trace[groupTraceIdx]);
+    });
+
+    it('test trace information2', async () => {
+      const users = [{
+        email: 'joe@bloggs.org',
+        groups: [
+          { orgIdent: '2345B0EA551D747', groupName: 4711 },
+          { orgIdent: '2345B0EA551D747', groupName: 'oxo' }
+        ]
+      }];
+      const aclCtx = await getAclCtx(env2, 'test', users, '/hark/hork/hoo');
+      const trace = aclCtx.actionTrace;
+
+      assert.strictEqual(3, trace.length);
+
+      const emailTraceIdx = trace[0].group === 'joebloggs.org' ? 0 : trace[1].group === 'joebloggs.org' ? 1 : 2;
+      const orgGrpTraceIdx = trace[0].group === '2345B0EA551D747/4711' ? 0 : trace[1].group === '2345B0EA551D747/4711' ? 1 : 2;
+      const orgTraceIdx = trace[0].group === '2345B0EA551D747' ? 0 : trace[1].group === '2345B0EA551D747' ? 1 : 2;
+
+      assert.deepStrictEqual({group: 'joe@bloggs.org', path: '/**', actions: ['read']}, trace[emailTraceIdx]);
+      assert.deepStrictEqual(
+        {
+          group: '2345B0EA551D747/4711',
+          path: '/**',
+          actions: [ 'read' ]
+        }, trace[orgGrpTraceIdx]);
+      assert.deepStrictEqual(
+        {
+          group: '2345B0EA551D747',
+          path: '/hark/hork/hoo',
+          actions: [ 'read', 'write' ]
+        }, trace[orgTraceIdx]);
     });
 
     it('test CONFIG api', async () => {


### PR DESCRIPTION
## Description

Removing them makes the acl processing more efficient and also avoids duplicates in the X-da-acltrace header.

The auth `getIdents()` function could return duplicates for users that are in multiple IMS groups within a single org.

## Related Issue

Fixes: #115

## How Has This Been Tested?

* Locally with da-collab and da-admin
* New unit test

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
