### PR TITLE
chore: make groups lower case for caseless email comparison

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -166,7 +166,7 @@ export async function getAclCtx(env, org, users, key, api) {
 
     // The ACLTRACE keyword is handled specially as its used for every request
     if (path.trim() === 'ACLTRACE' && actions?.includes('read')) {
-      groups.split(',').forEach((g) => aclTrace.push(g.trim()));
+      groups.split(',').forEach((g) => aclTrace.push(g.trim().toLowerCase()));
       return; // Don't add it to the list of paths
     }
 


### PR DESCRIPTION
it would be great to lower case emails, to get to a case less comparison.

i think that IMS always returns them lower case, but i am not sure if this would break something relative to the IMS orgs which seem to be uppercase

https://github.com/adobe/da-live/issues/421