### PR TITLE
Allow document GUID to be provided as parameter on creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Document Authoring Admin
+
 ## Introduction
 Document Authoring Admin is the API used to store and retrieve files and details from the Document Authoring content repository.
 
@@ -18,6 +19,7 @@ You can read the official API docs here: https://docs.da.live
 ```bash
 git clone git@github.com:adobe/da-admin
 ```
+
 #### 2. Install
 In a terminal, run `npm install` this repo's folder.
 
@@ -29,6 +31,7 @@ KV is used for high-performance R/W operations. This value is stored locally.
 ```bash
 npx wrangler kv:key put orgs '[{"name":"aemsites","created":"2023-10-31T17:43:13.390Z"}]' --binding=DA_AUTH --local
 ```
+
 #### 5. Start the local server
 At the root of the project folder, run `npm run dev`.
 

--- a/src/helpers/source.js
+++ b/src/helpers/source.js
@@ -42,6 +42,7 @@ function getFormEntries(formData) {
 
   if (formData.get('data')) {
     entries.data = formData.get('data');
+    entries.guid = formData.get('guid');
   }
 
   return entries;

--- a/src/storage/object/put.js
+++ b/src/storage/object/put.js
@@ -90,7 +90,7 @@ export default async function putObject(env, daCtx, obj) {
       const { body, type } = isFile ? await getFileBody(obj.data) : getObjectBody(obj.data);
       const res = await putObjectWithVersion(env, daCtx, {
         org, key, body, type,
-      });
+      }, false, obj.guid);
       status = res.status;
       metadata = res.metadata;
     }

--- a/src/storage/object/put.js
+++ b/src/storage/object/put.js
@@ -82,14 +82,17 @@ export default async function putObject(env, daCtx, obj) {
 
   const inputs = [];
 
+  let metadata = {};
   let status = 201;
   if (obj) {
     if (obj.data) {
       const isFile = obj.data instanceof File;
       const { body, type } = isFile ? await getFileBody(obj.data) : getObjectBody(obj.data);
-      status = await putObjectWithVersion(env, daCtx, {
+      const res = await putObjectWithVersion(env, daCtx, {
         org, key, body, type,
       });
+      status = res.status;
+      metadata = res.metadata;
     }
   } else {
     const { body, type } = getObjectBody({});
@@ -105,5 +108,7 @@ export default async function putObject(env, daCtx, obj) {
   }
 
   const body = sourceRespObject(daCtx);
-  return { body: JSON.stringify(body), status, contentType: 'application/json' };
+  return {
+    body: JSON.stringify(body), status, contentType: 'application/json', metadata,
+  };
 }

--- a/src/storage/version/put.js
+++ b/src/storage/version/put.js
@@ -157,7 +157,7 @@ export async function postObjectVersionWithLabel(label, env, daCtx) {
     org, key, body, contentLength, type: contentType, label,
   }, true);
 
-  return { status: resp === 200 ? 201 : resp.status };
+  return { status: resp.status === 200 ? 201 : resp.status };
 }
 
 export async function postObjectVersion(req, env, daCtx) {

--- a/src/utils/daResp.js
+++ b/src/utils/daResp.js
@@ -14,16 +14,21 @@ export default function daResp({
   body,
   contentType = 'application/json',
   contentLength,
+  metadata,
 }, ctx) {
   const headers = new Headers();
   headers.append('Access-Control-Allow-Origin', '*');
   headers.append('Access-Control-Allow-Methods', 'HEAD, GET, PUT, POST, DELETE');
   headers.append('Access-Control-Allow-Headers', '*');
-  headers.append('Access-Control-Expose-Headers', 'X-da-actions, X-da-child-actions, X-da-acltrace');
+  headers.append('Access-Control-Expose-Headers', 'X-da-actions, X-da-child-actions, X-da-acltrace, X-da-id');
   headers.append('Content-Type', contentType);
   if (contentLength) {
     headers.append('Content-Length', contentLength);
   }
+  if (metadata?.id) {
+    headers.append('X-da-id', metadata.id);
+  }
+
   if (ctx?.aclCtx && status < 500) {
     headers.append('X-da-actions', `/${ctx.key}=${[...ctx.aclCtx.actionSet]}`);
 

--- a/test/helpers/source.test.js
+++ b/test/helpers/source.test.js
@@ -15,7 +15,7 @@ describe('Source helper', () => {
       assert.strictEqual(helped, null);
     });
 
-    it('Returns null if unssupported content type', async () => {
+    it('Returns null if unsupported content type', async () => {
       const opts = {
         headers: new Headers({
           'Content-Type': `custom/form; boundary`,
@@ -58,6 +58,19 @@ describe('Source helper', () => {
 
       const helped = await putHelper(req, env, daCtx);
       assert.strictEqual(Object.keys(helped).length, 0);
+    });
+
+    it('Form with data field', async () => {
+      const body = new FormData();
+      body.append('data', 'foo');
+      body.append('guid', '12345');
+
+      const opts = { body, method: 'PUT' };
+      const req = new Request(MOCK_URL, opts);
+
+      const helped = await putHelper(req, env, daCtx);
+      assert.strictEqual('foo', helped.data);
+      assert.strictEqual('12345', helped.guid);
     });
   });
 });

--- a/test/storage/object/mocks/version/put.js
+++ b/test/storage/object/mocks/version/put.js
@@ -2,6 +2,6 @@ export async function postObjectVersion(env, daCtx) {
   return 200;
 }
 
-export async function putObjectWithVersion(env, daCtx, update, body) {
-  return 201;
+export async function putObjectWithVersion(env, daCtx, update, body, guid) {
+  return { status: 201, metadata: { id: guid}};
 }

--- a/test/storage/object/put.test.js
+++ b/test/storage/object/put.test.js
@@ -24,9 +24,10 @@ describe('Object storage', () => {
   describe('Put success', async () => {
     it('Successfully puts text data', async () => {
       const daCtx = { org: 'adobe', site: 'geometrixx', key: 'geometrixx', propsKey: 'geometrixx.props' };
-      const obj = { data: '<html></html>' };
+      const obj = { data: '<html></html>', guid: '8888' };
       const resp = await putObject(env, daCtx, obj);
       assert.strictEqual(resp.status, 201);
+      assert.strictEqual(resp.metadata.id, '8888');
     });
 
     it('Successfully puts file data', async () => {

--- a/test/utils/daResp.test.js
+++ b/test/utils/daResp.test.js
@@ -19,17 +19,19 @@ describe('DA Resp', () => {
     const aclCtx = { actionSet: ['read', 'write'], pathLookup: new Map() };
     const ctx = { key: 'foo/bar.html', aclCtx };
     const body = 'foobar';
+    const metadata = { id: '1234' };
 
-    const resp = daResp({status: 200, body, contentType: 'text/plain', contentLength: 777}, ctx);
+    const resp = daResp({status: 200, body, contentType: 'text/plain', contentLength: 777, metadata}, ctx);
     assert.strictEqual(body, await resp.text());
     assert.strictEqual(200, resp.status);
     assert.strictEqual('*', resp.headers.get('Access-Control-Allow-Origin'));
     assert.strictEqual('HEAD, GET, PUT, POST, DELETE', resp.headers.get('Access-Control-Allow-Methods'));
     assert.strictEqual('*', resp.headers.get('Access-Control-Allow-Headers'));
-    assert.strictEqual('X-da-actions, X-da-child-actions, X-da-acltrace', resp.headers.get('Access-Control-Expose-Headers'));
+    assert.strictEqual('X-da-actions, X-da-child-actions, X-da-acltrace, X-da-id', resp.headers.get('Access-Control-Expose-Headers'));
     assert.strictEqual('text/plain', resp.headers.get('Content-Type'));
     assert.strictEqual('777', resp.headers.get('Content-Length'));
     assert.strictEqual('/foo/bar.html=read,write', resp.headers.get('X-da-actions'));
+    assert.strictEqual('1234', resp.headers.get('X-da-id'));
     assert(resp.headers.get('X-da-acltrace') === null);
   });
 
@@ -38,17 +40,19 @@ describe('DA Resp', () => {
     const aclCtx = { actionSet: ['read'], pathLookup: new Map(), actionTrace };
     const ctx = { key: 'foo/blah.html', aclCtx };
     const body = null;
+    const metadata = {};
 
-    const resp = daResp({status: 404, body}, ctx);
+    const resp = daResp({status: 404, body, metadata}, ctx);
     assert.strictEqual(404, resp.status);
     assert.strictEqual('*', resp.headers.get('Access-Control-Allow-Origin'));
     assert.strictEqual('HEAD, GET, PUT, POST, DELETE', resp.headers.get('Access-Control-Allow-Methods'));
     assert.strictEqual('*', resp.headers.get('Access-Control-Allow-Headers'));
-    assert.strictEqual('X-da-actions, X-da-child-actions, X-da-acltrace', resp.headers.get('Access-Control-Expose-Headers'));
+    assert.strictEqual('X-da-actions, X-da-child-actions, X-da-acltrace, X-da-id', resp.headers.get('Access-Control-Expose-Headers'));
     assert.strictEqual('application/json', resp.headers.get('Content-Type'));
     assert(!resp.headers.get('Content-Length'));
     assert.strictEqual('/foo/blah.html=read', resp.headers.get('X-da-actions'));
     assert.deepStrictEqual(actionTrace, JSON.parse(resp.headers.get('X-da-acltrace')));
+    assert(resp.headers.get('X-da-id') === null);
   });
 
   it('test 500', () => {
@@ -62,6 +66,7 @@ describe('DA Resp', () => {
     assert(resp.headers.get('X-da-actions') === null);
     assert(resp.headers.get('X-da-child-actions') === null);
     assert(resp.headers.get('X-da-acltrace') === null);
+    assert(resp.headers.get('X-da-id') === null);
   });
 
   it('test child actions header', () => {
@@ -69,7 +74,7 @@ describe('DA Resp', () => {
     const ctx = { key: 'foo/bar.html', aclCtx }
     const resp = daResp({status: 200, body: 'foobar'}, ctx);
     assert.strictEqual(200, resp.status);
-    assert.strictEqual('X-da-actions, X-da-child-actions, X-da-acltrace', resp.headers.get('Access-Control-Expose-Headers'));
+    assert.strictEqual('X-da-actions, X-da-child-actions, X-da-acltrace, X-da-id', resp.headers.get('Access-Control-Expose-Headers'));
     assert.strictEqual('/haha/hoho/**=read,write', resp.headers.get('X-da-child-actions'));
   })
 });


### PR DESCRIPTION
## Description

The ID of the document can be provided on creation through the `guid` parameter as part of the Form Data. 

When requesting a document it's ID is reported via the `X-da-id` header in the response.

## Related Issue

https://github.com/adobe/da-live/issues/378

## How Has This Been Tested?

* Added unit test
* Locally with da-live and da-collab

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
