### PR TITLE
feat: return last modified for source based on timestamp

### DIFF
--- a/src/utils/daResp.js
+++ b/src/utils/daResp.js
@@ -29,6 +29,10 @@ export default function daResp({
     headers.append('X-da-id', metadata.id);
   }
 
+  if (metadata?.timestamp) {
+    headers.append('Last-Modified', new Date(parseInt(metadata.timestamp, 10)).toUTCString());
+  }
+
   if (ctx?.aclCtx && status < 500) {
     headers.append('X-da-actions', `/${ctx.key}=${[...ctx.aclCtx.actionSet]}`);
 

--- a/test/utils/daResp.test.js
+++ b/test/utils/daResp.test.js
@@ -19,7 +19,7 @@ describe('DA Resp', () => {
     const aclCtx = { actionSet: ['read', 'write'], pathLookup: new Map() };
     const ctx = { key: 'foo/bar.html', aclCtx };
     const body = 'foobar';
-    const metadata = { id: '1234' };
+    const metadata = { id: '1234', timestamp: '1719235200000' };
 
     const resp = daResp({status: 200, body, contentType: 'text/plain', contentLength: 777, metadata}, ctx);
     assert.strictEqual(body, await resp.text());
@@ -32,6 +32,7 @@ describe('DA Resp', () => {
     assert.strictEqual('777', resp.headers.get('Content-Length'));
     assert.strictEqual('/foo/bar.html=read,write', resp.headers.get('X-da-actions'));
     assert.strictEqual('1234', resp.headers.get('X-da-id'));
+    assert.strictEqual('Mon, 24 Jun 2024 13:20:00 GMT', resp.headers.get('Last-Modified'));
     assert(resp.headers.get('X-da-acltrace') === null);
   });
 


### PR DESCRIPTION
## Description

Return `Last-Modified` response header for /source GET & HEAD requests.

## Related Issue

fixes: #128 

