### PR TITLE
fix: last modified header for source

### DIFF
--- a/src/storage/object/get.js
+++ b/src/storage/object/get.js
@@ -36,7 +36,10 @@ export default async function getObject(env, { org, key }, head = false) {
         status: resp.$metadata.httpStatusCode,
         contentType: resp.ContentType,
         contentLength: resp.ContentLength,
-        metadata: resp.Metadata,
+        metadata: {
+          ...resp.Metadata,
+          LastModified: resp.LastModified,
+        },
         etag: resp.ETag,
       };
     } catch (e) {
@@ -56,7 +59,10 @@ export default async function getObject(env, { org, key }, head = false) {
     status: resp.status,
     contentType: resp.headers.get('content-type'),
     contentLength: resp.headers.get('content-length'),
-    metadata: Metadata,
+    metadata: {
+      ...resp.Metadata,
+      LastModified: resp.headers.get('last-modified'),
+    },
     etag: resp.headers.get('etag'),
   };
 }

--- a/src/utils/daResp.js
+++ b/src/utils/daResp.js
@@ -29,8 +29,8 @@ export default function daResp({
     headers.append('X-da-id', metadata.id);
   }
 
-  if (metadata?.timestamp) {
-    headers.append('Last-Modified', new Date(parseInt(metadata.timestamp, 10)).toUTCString());
+  if (metadata?.LastModified) {
+    headers.append('Last-Modified', new Date(metadata.LastModified).toUTCString());
   }
 
   if (ctx?.aclCtx && status < 500) {

--- a/test/utils/daResp.test.js
+++ b/test/utils/daResp.test.js
@@ -19,7 +19,7 @@ describe('DA Resp', () => {
     const aclCtx = { actionSet: ['read', 'write'], pathLookup: new Map() };
     const ctx = { key: 'foo/bar.html', aclCtx };
     const body = 'foobar';
-    const metadata = { id: '1234', timestamp: '1719235200000' };
+    const metadata = { id: '1234', LastModified: '2024-06-24T13:20:00.000Z' };
 
     const resp = daResp({status: 200, body, contentType: 'text/plain', contentLength: 777, metadata}, ctx);
     assert.strictEqual(body, await resp.text());


### PR DESCRIPTION
## Description

Fix the last modified header for GET & HEAD /source, use the R2/S3 last modified date instead of the timestamp. This is now aligned with the /list API response as well https://github.com/adobe/da-admin/blob/a384662b6ecd9af80b3ad9ead5fa9b6763ebfcc2/src/storage/utils/list.js#L67

