### PR TITLE
feat: add a restore point if body is empty

### DIFF
--- a/src/storage/version/put.js
+++ b/src/storage/version/put.js
@@ -14,6 +14,7 @@ import {
   PutObjectCommand,
 } from '@aws-sdk/client-s3';
 
+import { EMPTY_DOC_SIZE } from '../../utils/constants.js';
 import getS3Config from '../utils/config.js';
 import {
   getUsersForMetadata, ifMatch, ifNoneMatch,
@@ -118,7 +119,7 @@ export async function putObjectWithVersion(env, daCtx, update, body, guid) {
   const Preparsingstore = storeBody ? Timestamp : pps;
   let Label = storeBody ? 'Collab Parse' : update.label;
 
-  if (daCtx.method === 'PUT' && current.contentLength > 83 && (!update.body || update.body.size <= 83)) {
+  if (daCtx.method === 'PUT' && current.contentLength > EMPTY_DOC_SIZE && (!update.body || update.body.size <= EMPTY_DOC_SIZE)) {
     // we are about to empty the document body
     // this should never happen but in some cases it does
     // we want then to store a version of the full document as a restore point

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -20,3 +20,7 @@ export const SUPPORTED_TYPES = [
   'image/svg+xml',
   'video/mp4',
 ];
+
+// this is the size of the empty document
+// <body><header></header><main><div></div></main><footer></footer></body>
+export const EMPTY_DOC_SIZE = 83;

--- a/src/utils/daCtx.js
+++ b/src/utils/daCtx.js
@@ -44,6 +44,7 @@ export default async function getDaCtx(req, env) {
     users,
     fullKey,
     origin: new URL(req.url).origin,
+    method: req.method,
   };
 
   // Sanitize the remaining path parts


### PR DESCRIPTION
There are rare cases when the document is emptied. We did not get to the root cause yet.

My proposal here: save the last version of the document before empty by adding a "Restore Point" labelled version with the document before it gets stored as empty. 
While this does not fix the initial problem, it will help authors to restore the document but it will also help us identify when this occurs exactly and potentially identify the root cause.

Appears like this in the UI:

<img width="1290" height="370" alt="image" src="https://github.com/user-attachments/assets/2b018578-cc91-48f6-9e9a-eb661ca7c156" />
