### PR TITLE
fix(versionsource): "delegate" permission check to api

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -297,7 +297,7 @@ export async function getAclCtx(env, org, users, key, api) {
   // Expose the action trace or not?
   actionTrace = users.every((u) => aclTrace.includes(u.email)) ? actionTrace : undefined;
 
-  if (k === 'CONFIG') {
+  if (k === 'CONFIG' || api === 'versionsource') {
     actionSet.add('read');
   }
 

--- a/test/utils/auth.test.js
+++ b/test/utils/auth.test.js
@@ -302,7 +302,20 @@ describe('DA auth', () => {
       const users = [{email: "blah@foo.org"}];
       const aclCtx = await getAclCtx(env2, 'test', users, '/', 'config');
       assert(aclCtx.actionSet.has('read'));
-    })
+    });
+
+    it('test versionsource api always has read permission', async () => {
+      const users = [{email: "blah@foo.org"}];
+      const aclCtx = await getAclCtx(env2, 'test', users, '/', 'versionsource');
+      assert(aclCtx.actionSet.has('read'));
+    });
+
+    it('test versionsource api grants read permission even without explicit permissions', async () => {
+      const users = [{email: "unauthorized@example.com"}];
+      const aclCtx = await getAclCtx(env2, 'test', users, '/restricted', 'versionsource');
+      assert(aclCtx.actionSet.has('read'));
+      assert(!aclCtx.actionSet.has('write'));
+    });
   });
 
   describe('persmissions single sheet', () => {


### PR DESCRIPTION
Fix https://github.com/adobe/da-admin/issues/175

This allows any request to `/versionsource` to pass the first step (basically = to "allow API to all"). Then API `getVersionSource` checks the document read access. If no read access to document, 403.