### PR TITLE
chore: log gzip encoded content

### DIFF
--- a/src/storage/object/get.js
+++ b/src/storage/object/get.js
@@ -31,6 +31,13 @@ export default async function getObject(env, { bucket, org, key }, head = false)
   if (!head) {
     try {
       const resp = await client.send(new GetObjectCommand(input));
+
+      if (resp.ContentEncoding === 'gzip') {
+        // eslint-disable-next-line no-console
+        console.warn('Content is gzip encoded - request might fail');
+        throw new Error('Corrupted content');
+      }
+
       return {
         body: resp.Body,
         status: resp.$metadata.httpStatusCode,

--- a/src/storage/object/get.js
+++ b/src/storage/object/get.js
@@ -32,11 +32,14 @@ export default async function getObject(env, { bucket, org, key }, head = false)
     try {
       const resp = await client.send(new GetObjectCommand(input));
 
+      // c8 ignore start
       if (resp.ContentEncoding === 'gzip') {
+        // log to track which documents are gzip encoded and run scripts to fix them
         // eslint-disable-next-line no-console
         console.warn('Content is gzip encoded - request might fail');
         throw new Error('Corrupted content');
       }
+      // c8 ignore end
 
       return {
         body: resp.Body,

--- a/src/storage/object/get.js
+++ b/src/storage/object/get.js
@@ -32,14 +32,14 @@ export default async function getObject(env, { bucket, org, key }, head = false)
     try {
       const resp = await client.send(new GetObjectCommand(input));
 
-      // c8 ignore start
+      /* c8 ignore start */
       if (resp.ContentEncoding === 'gzip') {
         // log to track which documents are gzip encoded and run scripts to fix them
         // eslint-disable-next-line no-console
         console.warn('Content is gzip encoded - request might fail');
         throw new Error('Corrupted content');
       }
-      // c8 ignore end
+      /* c8 ignore end */
 
       return {
         body: resp.Body,


### PR DESCRIPTION
Write a log warning to track the documents that corrupted and used. Then I can run script to fix those.